### PR TITLE
Walidacja obiektu scenicznego

### DIFF
--- a/frontend/src/components/modals/sceneObject/ConfigureSceneObjectModal.vue
+++ b/frontend/src/components/modals/sceneObject/ConfigureSceneObjectModal.vue
@@ -37,6 +37,7 @@ import SelectSceneObjectTypeModal from "@/components/modals/type/SelectSceneObje
 import SelectConverterModal from "@/components/modals/converter/SelectConverterModal.vue";
 import { mapActions, mapState } from "vuex";
 import { closeModal, pushModal } from "jenesius-vue-modal";
+import { validateSceneObject } from "@/javascript/utils/validationUtils";
 
 export default {
     components: { AlgoModal, AlgoTable, AlgoLink, AlgoFieldRow, AlgoButton },
@@ -63,22 +64,7 @@ export default {
         ...mapActions("project", ["saveSceneObject"]),
 
         save() {
-            const assert = (assertion, warning) => {
-                if (!assertion) {
-                    alert(warning); //TODO: Toast zamiast alerta
-                    return false;
-                }
-                return true;
-            };
-
-            if (!assert(this.model.type != null, "Podaj rodzaj obiektu")) return;
-            if (!assert(this.model.variable != null, "Przypisz zmienną")) return;
-            let ok = true;
-            this.model.subobjects.forEach((subObj) => {
-                if (!assert(subObj.type != null, "Podaj rodzaj właściwości")) return (ok = false);
-                if (!assert(subObj.variable != null, "Przypisz zmienną do właściwości")) return (ok = false);
-            });
-            if (!ok) return;
+            if (!validateSceneObject(this.model)) return;
 
             this.saveSceneObject(this.model);
             closeModal();

--- a/frontend/src/components/modals/sceneObject/ConfigureSceneObjectModal.vue
+++ b/frontend/src/components/modals/sceneObject/ConfigureSceneObjectModal.vue
@@ -63,6 +63,23 @@ export default {
         ...mapActions("project", ["saveSceneObject"]),
 
         save() {
+            const assert = (assertion, warning) => {
+                if (!assertion) {
+                    alert(warning); //TODO: Toast zamiast alerta
+                    return false;
+                }
+                return true;
+            };
+
+            if (!assert(this.model.type != null, "Podaj rodzaj obiektu")) return;
+            if (!assert(this.model.variable != null, "Przypisz zmienną")) return;
+            let ok = true;
+            this.model.subobjects.forEach((subObj) => {
+                if (!assert(subObj.type != null, "Podaj rodzaj właściwości")) return (ok = false);
+                if (!assert(subObj.variable != null, "Przypisz zmienną do właściwości")) return (ok = false);
+            });
+            if (!ok) return;
+
             this.saveSceneObject(this.model);
             closeModal();
         },

--- a/frontend/src/javascript/utils/validationUtils.js
+++ b/frontend/src/javascript/utils/validationUtils.js
@@ -1,0 +1,17 @@
+export function validateSceneObject(model) {
+    if (!assert(model.type != null, "Podaj rodzaj obiektu")) return false;
+    if (!assert(model.variable != null, "Przypisz zmienną")) return false;
+    model.subobjects.forEach((subObj) => {
+        if (!assert(subObj.type != null, "Podaj rodzaj właściwości")) return false;
+        if (!assert(subObj.variable != null, "Przypisz zmienną do właściwości")) return false;
+    });
+    return true;
+}
+
+function assert(assertion, warning) {
+    if (!assertion) {
+        alert(warning); //TODO: Toast zamiast alerta
+        return false;
+    }
+    return true;
+}


### PR DESCRIPTION
https://trello.com/c/YakOOADz/37-walidacja-obiektu-scenicznego

Walidacja tylko na froncie.

Teoretycznie zrobione bez większego problemu, ale zamiast alert() dobry komunikat musi poczekać do Toastów (nie widzę sensu robić tekstu w popupie, skoro docelowo w tym sprincie i tak je dodajemy).