### PR TITLE
Pobranie listy projektów i konwerterów w tle

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -22,8 +22,8 @@ export default {
     components: { Menu, MainPage, Modal: container },
 
     mounted() {
-        store.dispatch("cachedLists/updateProjectsList");
-        store.dispatch("cachedLists/updateConvertersList");
+        store.dispatch("cachedLists/updateProjects");
+        store.dispatch("cachedLists/updateConverters");
     },
 };
 </script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,7 +14,7 @@
 import Menu from "@/components/menu/Menu.vue";
 import MainPage from "@/components/mainPage/MainPage.vue";
 import { container } from "jenesius-vue-modal";
-import store from "@/store";
+import { mapActions } from "vuex";
 
 export default {
     // ERROR: Name "Menu" is reserved in HTML
@@ -22,8 +22,12 @@ export default {
     components: { Menu, MainPage, Modal: container },
 
     mounted() {
-        store.dispatch("cachedLists/updateProjects");
-        store.dispatch("cachedLists/updateConverters");
+        this.updateProjects();
+        this.updateConverters();
+    },
+
+    methods: {
+        ...mapActions("cachedLists", ["updateProjects", "updateConverters"]),
     },
 };
 </script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,11 +14,17 @@
 import Menu from "@/components/menu/Menu.vue";
 import MainPage from "@/components/mainPage/MainPage.vue";
 import { container } from "jenesius-vue-modal";
+import store from "@/store";
 
 export default {
     // ERROR: Name "Menu" is reserved in HTML
     // eslint-disable-next-line
     components: { Menu, MainPage, Modal: container },
+
+    mounted() {
+        store.dispatch("cachedLists/updateProjectsList");
+        store.dispatch("cachedLists/updateConvertersList");
+    },
 };
 </script>
 

--- a/frontend/src/components/modals/converter/SelectConverterModal.vue
+++ b/frontend/src/components/modals/converter/SelectConverterModal.vue
@@ -1,6 +1,6 @@
 <template>
     <AlgoModal title="Wybierz konwerter">
-        <AlgoPickList :options="converters" @selectOptionEvent="handleSelectOption" />
+        <AlgoPickList :options="convertersList" @selectOptionEvent="handleSelectOption" />
 
         <template #buttons>
             <AlgoButton @click="createConverter()">Utwórz nowy kowerter</AlgoButton>
@@ -13,31 +13,21 @@ import AlgoModal from "@/components/global/AlgoModal.vue";
 import AlgoPickList from "@/components/global/AlgoPickList.vue";
 import AlgoButton from "@/components/global/AlgoButton.vue";
 import CreateConverterModal from "@/components/modals/converter/CreateConverterModal.vue";
-import { sendRequest } from "@/javascript/utils/axiosUtils";
-import { getDialogDataForConverter } from "@/javascript/utils/dialogUtils";
 import { popModal, pushModal } from "jenesius-vue-modal";
+import { mapActions, mapGetters } from "vuex";
 
 export default {
     components: { AlgoModal, AlgoPickList, AlgoButton },
 
     props: ["callback"],
 
-    data() {
-        return {
-            converters: [],
-        };
-    },
-
     created() {
-        sendRequest("/converter/findAll", null, "GET").then((responseData) => {
-            this.converters = responseData;
-            this.converters.forEach((converter) => {
-                converter.dialogData = getDialogDataForConverter(converter);
-            });
-        });
+        this.updateConvertersList();
     },
 
     methods: {
+        ...mapActions("cachedLists", ["updateConvertersList"]),
+
         handleSelectOption(selectedConverter) {
             this.$props.callback(selectedConverter);
             popModal();
@@ -46,11 +36,14 @@ export default {
         createConverter() {
             pushModal(CreateConverterModal, {
                 callback: (newConverter) => {
-                    this.converters.push(newConverter);
                     this.handleSelectOption(newConverter);
                 },
             });
         },
+    },
+
+    computed: {
+        ...mapGetters("cachedLists", ["convertersList"]),
     },
 };
 </script>

--- a/frontend/src/components/modals/converter/SelectConverterModal.vue
+++ b/frontend/src/components/modals/converter/SelectConverterModal.vue
@@ -1,6 +1,6 @@
 <template>
     <AlgoModal title="Wybierz konwerter">
-        <AlgoPickList :options="convertersList" @selectOptionEvent="handleSelectOption" />
+        <AlgoPickList :options="converters" @selectOptionEvent="handleSelectOption" />
 
         <template #buttons>
             <AlgoButton @click="createConverter()">Utwórz nowy kowerter</AlgoButton>
@@ -22,11 +22,11 @@ export default {
     props: ["callback"],
 
     created() {
-        this.updateConvertersList();
+        this.updateConverters();
     },
 
     methods: {
-        ...mapActions("cachedLists", ["updateConvertersList"]),
+        ...mapActions("cachedLists", ["updateConverters"]),
 
         handleSelectOption(selectedConverter) {
             this.$props.callback(selectedConverter);
@@ -43,7 +43,7 @@ export default {
     },
 
     computed: {
-        ...mapGetters("cachedLists", ["convertersList"]),
+        ...mapGetters("cachedLists", ["converters"]),
     },
 };
 </script>

--- a/frontend/src/components/modals/menu/LoadProjectModal.vue
+++ b/frontend/src/components/modals/menu/LoadProjectModal.vue
@@ -1,37 +1,32 @@
 <template>
     <AlgoModal title="Wczytaj projekt">
-        <AlgoPickList :options="projects" @selectOptionEvent="loadProject" />
+        <AlgoPickList :options="projectsList" @selectOptionEvent="loadProject" />
     </AlgoModal>
 </template>
 
 <script>
 import AlgoModal from "@/components/global/AlgoModal.vue";
 import AlgoPickList from "@/components/global/AlgoPickList.vue";
-import { sendRequest } from "@/javascript/utils/axiosUtils";
 import { redirectTo } from "@/javascript/utils/other";
-import { getDialogDataForProject } from "@/javascript/utils/dialogUtils";
+import { mapActions, mapGetters } from "vuex";
 
 export default {
     components: { AlgoModal, AlgoPickList },
-    data() {
-        return {
-            projects: [],
-        };
-    },
 
     created() {
-        sendRequest("/project/findAll", null, "GET").then((responseData) => {
-            this.projects = responseData;
-            this.projects.forEach((project) => {
-                project.dialogData = getDialogDataForProject(project);
-            });
-        });
+        this.updateProjectsList();
     },
 
     methods: {
+        ...mapActions("cachedLists", ["updateProjectsList"]),
+
         loadProject(selectedProject) {
             redirectTo("?projectId=" + selectedProject._id);
         },
+    },
+
+    computed: {
+        ...mapGetters("cachedLists", ["projectsList"]),
     },
 };
 </script>

--- a/frontend/src/components/modals/menu/LoadProjectModal.vue
+++ b/frontend/src/components/modals/menu/LoadProjectModal.vue
@@ -1,6 +1,6 @@
 <template>
     <AlgoModal title="Wczytaj projekt">
-        <AlgoPickList :options="projectsList" @selectOptionEvent="loadProject" />
+        <AlgoPickList :options="projects" @selectOptionEvent="loadProject" />
     </AlgoModal>
 </template>
 
@@ -14,11 +14,11 @@ export default {
     components: { AlgoModal, AlgoPickList },
 
     created() {
-        this.updateProjectsList();
+        this.updateProjects();
     },
 
     methods: {
-        ...mapActions("cachedLists", ["updateProjectsList"]),
+        ...mapActions("cachedLists", ["updateProjects"]),
 
         loadProject(selectedProject) {
             redirectTo("?projectId=" + selectedProject._id);
@@ -26,7 +26,7 @@ export default {
     },
 
     computed: {
-        ...mapGetters("cachedLists", ["projectsList"]),
+        ...mapGetters("cachedLists", ["projects"]),
     },
 };
 </script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -19,6 +19,3 @@ app.use(VueKonva);
 app.use(store);
 app.use(Toast, getDefaultToastSettings());
 app.mount("#app");
-
-store.dispatch("cachedLists/updateProjectsList"); //TODO: Nie wiem gdzie to powinno się znaleźć, na razie jest tu bo działa.
-store.dispatch("cachedLists/updateConvertersList"); //TODO: Nie wiem gdzie to powinno się znaleźć, na razie jest tu bo działa.

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -19,3 +19,6 @@ app.use(VueKonva);
 app.use(store);
 app.use(Toast, getDefaultToastSettings());
 app.mount("#app");
+
+store.dispatch("cachedLists/updateProjectsList"); //TODO: Nie wiem gdzie to powinno się znaleźć, na razie jest tu bo działa.
+store.dispatch("cachedLists/updateConvertersList"); //TODO: Nie wiem gdzie to powinno się znaleźć, na razie jest tu bo działa.

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,8 +1,10 @@
 import { createStore } from "vuex";
 import project from "./modules/project";
+import cachedLists from "./modules/cachedLists";
 
 export default createStore({
     modules: {
         project,
+        cachedLists,
     },
 });

--- a/frontend/src/store/modules/cachedLists.js
+++ b/frontend/src/store/modules/cachedLists.js
@@ -1,0 +1,50 @@
+import { sendRequest } from "@/javascript/utils/axiosUtils";
+import { getDialogDataForProject, getDialogDataForConverter } from "@/javascript/utils/dialogUtils";
+
+export default {
+    namespaced: true,
+    state: {
+        projectsList: [],
+        convertersList: [],
+    },
+
+    getters: {
+        projectsList(state) {
+            return state.projectsList;
+        },
+
+        convertersList(state) {
+            return state.convertersList;
+        },
+    },
+
+    mutations: {
+        setProjectsList(state, projectsList) {
+            state.projectsList = projectsList;
+        },
+
+        setConvertersList(state, convertersList) {
+            state.convertersList = convertersList;
+        },
+    },
+
+    actions: {
+        updateProjectsList({ commit }) {
+            sendRequest("/project/findAll", null, "GET").then((responseData) => {
+                responseData.forEach((project) => {
+                    project.dialogData = getDialogDataForProject(project);
+                });
+                commit("setProjectsList", responseData);
+            });
+        },
+
+        updateConvertersList({ commit }) {
+            sendRequest("/converter/findAll", null, "GET").then((responseData) => {
+                responseData.forEach((converter) => {
+                    converter.dialogData = getDialogDataForConverter(converter);
+                });
+                commit("setConvertersList", responseData);
+            });
+        },
+    },
+};

--- a/frontend/src/store/modules/cachedLists.js
+++ b/frontend/src/store/modules/cachedLists.js
@@ -4,46 +4,46 @@ import { getDialogDataForProject, getDialogDataForConverter } from "@/javascript
 export default {
     namespaced: true,
     state: {
-        projectsList: [],
-        convertersList: [],
+        projects: [],
+        converters: [],
     },
 
     getters: {
-        projectsList(state) {
-            return state.projectsList;
+        projects(state) {
+            return state.projects;
         },
 
-        convertersList(state) {
-            return state.convertersList;
+        converters(state) {
+            return state.converters;
         },
     },
 
     mutations: {
-        setProjectsList(state, projectsList) {
-            state.projectsList = projectsList;
+        setProjects(state, projects) {
+            state.projects = projects;
         },
 
-        setConvertersList(state, convertersList) {
-            state.convertersList = convertersList;
+        setConverters(state, converters) {
+            state.converters = converters;
         },
     },
 
     actions: {
-        updateProjectsList({ commit }) {
+        updateProjects({ commit }) {
             sendRequest("/project/findAll", null, "GET").then((responseData) => {
                 responseData.forEach((project) => {
                     project.dialogData = getDialogDataForProject(project);
                 });
-                commit("setProjectsList", responseData);
+                commit("setProjects", responseData);
             });
         },
 
-        updateConvertersList({ commit }) {
+        updateConverters({ commit }) {
             sendRequest("/converter/findAll", null, "GET").then((responseData) => {
                 responseData.forEach((converter) => {
                     converter.dialogData = getDialogDataForConverter(converter);
                 });
-                commit("setConvertersList", responseData);
+                commit("setConverters", responseData);
             });
         },
     },


### PR DESCRIPTION
Stworzyłem store w vuex "cachedLists". Zawiera on projects i converters. Pobierane są po wyrenderowaniu strony oraz po każdym otwarciu okna z odpowiednią listą. 
Aktualnie nie działa zapisywanie konwerterów do bazy, więc myślałem nad listą typu localConverters, żeby w przypadku podobnego błędu konwertery zapisywały się w tej drugiej liście, ale odrzuciłem to, bo taki błąd docelowo pojawiać się nie powinien, a program i tak działa (z tym że nie zapisuje pobranych konwerterów). Poprzednio zapisywanie konwertera dopisywało go też lokalnie, ale ponowne otwarcie okna i tak pobierało aktualną listę z serwera, wymazując dodany konwerter. Teraz konwertery polegają tylko na cache i syncu z bazą.
Co do projects/findAll mam sugestię, żeby nie zwracać całego kodu każdego projektu + dodać jakąś paginację/limit. Jak tych projektów będzie 100 czy 1000 to pobieranie tylu kodów źródłowych po każdym kliknięciu "open project" nie jest dobrym pomysłem.
W kolejnym sprincie można pomyśleć nad listami localProjects i localConverters, żeby niezalogowany użytkownik też mógł trzymać jakieś swoje kody.