### PR TITLE
[Bug] Usuwanie jednego obiektu scenicznego usuwa także następny

### DIFF
--- a/frontend/src/components/mainPage/scene/subcomponents/SceneObjectsPanel.vue
+++ b/frontend/src/components/mainPage/scene/subcomponents/SceneObjectsPanel.vue
@@ -1,14 +1,13 @@
 <template>
     <div class="scene-objects-panel-container">
         <v-chip
-            closable
             v-for="(sceneObject, index) in sceneObjects"
             class="ma-2"
             :key="index"
             @click="configureSceneObject(sceneObject, $event)"
-            @click:close="deleteSceneObject(index)"
         >
             {{ sceneObject.type.label }} {{ sceneObject.variable ? sceneObject.variable.name : "null" }}
+            <v-icon icon="mdi-close-circle ms-2" variant="plain" size="18" @click="deleteSceneObject(index)" />
         </v-chip>
     </div>
 </template>


### PR DESCRIPTION
https://trello.com/c/oqA4Z3AL/58-bug-usuwanie-jednego-obiektu-scenicznego-usuwa-tak%C5%BCe-nast%C4%99pny

Problem jest z tym że obiekty sceniczne nie mają unikatowych wartości w atrybucie `key`. Przez co występują błędy w renderowaniu. Wymaganie unikatowości klucza jest wspomniane także w dokumentacji Vue.
https://vuejs.org/api/built-in-special-attributes.html#key

Dla przykładu:
Mamy 3 obiekty sceniczne a, b, c
`a ma klucz 0, b ma klucz 1, c ma klucz 2`
Gdy usuniemy a to mamy
`b ma klucz 0, c ma klucz 1`
I tutaj jest problem z unikatowością, nagle obiekt sceniczny b ma klucz po a który został przed chwilą usunięty.

Zastosowałem hotfix, który omija wspomniane w dokumentacji "render errors" ale i tak będzie trzeba się zająć unikatowością kluczy dla wszystkich v-for w innym tasku.

Chciałem skorzystać z `sceneObject._id` lecz jest on pusty w nowych projektach.