### PR TITLE
Add std to cout and endl

### DIFF
--- a/frontend/src/components/modals/converter/CreateConverterModal.vue
+++ b/frontend/src/components/modals/converter/CreateConverterModal.vue
@@ -29,7 +29,7 @@
             return {
                 converter: {
                     title: "",
-                    code: "ostream& operator <<(ostream& os, const <typ> <nazwa>) {\n\t// Konwersja obiektu na string \n\treturn os;\n}",
+                    code: "std::ostream& operator <<(std::ostream& os, const <typ> <nazwa>) {\n\t// Konwersja obiektu na string \n\treturn os;\n}",
                 },
             };
         },

--- a/frontend/src/javascript/codeParser/CodeParser.js
+++ b/frontend/src/javascript/codeParser/CodeParser.js
@@ -147,8 +147,8 @@ class CodeUtils {
     static insertAlgodebugMacros(code) {
         return (
             `#define ALGODEBUG_VARIABLE(x) "<algodebug-variable " << "name=\\"" << #x << "\\">\\n" << x << "\\n</algodebug-variable>\\n"\n` +
-            `#define ALGODEBUG_BREAKPOINT(line, x) cout << "<algodebug-breakpoint " << "line=\\"" << line << "\\">\\n" << x << "</algodebug-breakpoint>\\n"\n` +
-            `#define ALGODEBUG_EMPTY_BREAKPOINT(line) cout << "<algodebug-breakpoint " << "line=\\"" << line << "\\">\\n</algodebug-breakpoint>\\n"\n\n` +
+            `#define ALGODEBUG_BREAKPOINT(line, x) std::cout << "<algodebug-breakpoint " << "line=\\"" << line << "\\">\\n" << x << "</algodebug-breakpoint>\\n"\n` +
+            `#define ALGODEBUG_EMPTY_BREAKPOINT(line) std::cout << "<algodebug-breakpoint " << "line=\\"" << line << "\\">\\n</algodebug-breakpoint>\\n"\n\n` +
             code
         );
     }


### PR DESCRIPTION
https://trello.com/c/zfa83R05/80-bug-kod-bez-using-namespace-std-si%C4%99-nie-kompiluje

W bazie wciąż są konwertery używające ostream i cout bez std::.