### PR TITLE
[Bug] Kod bez #include <iostream> nie skompiluje się

### DIFF
--- a/frontend/src/javascript/codeParser/CodeParser.js
+++ b/frontend/src/javascript/codeParser/CodeParser.js
@@ -101,6 +101,7 @@ export class CodeParser {
         this.code = CodeUtils.insertConvertersAfterIncludes(this.code, this.converters);
         this.code = CodeUtils.insertConvertersAtTheEnd(this.code, this.converters);
         this.code = CodeUtils.insertAlgodebugMacros(this.code);
+        this.code = CodeUtils.insertNecessaryIncludes(this.code);
     }
 }
 
@@ -171,5 +172,13 @@ class CodeUtils {
     static insertConvertersAtTheEnd(code, converters) {
         converters = converters.map((converter) => converter.code).join("\n\n");
         return code + "\n\n" + converters;
+    }
+
+    static insertNecessaryIncludes(code) {
+        const regex = /#include[ \t]<iostream>/g;
+        if (!regex.test(code)) {
+            return "#include <iostream>\n" + code;
+        }
+        return code;
     }
 }


### PR DESCRIPTION
https://trello.com/c/I5L2IFKD/93-bug-kod-bez-include-iostream-nie-skompiluje-si%C4%99

Teoretycznie nie trzeba sprawdzać, czy ten include już jest w kodzie, bo dwukrotne wystąpienie `#include <iostream>` nie rzuca błędem, ale i tak dodałem prostego regexa.