### PR TITLE
[Bug] Podwójne pobieranie klatki animacji

### DIFF
--- a/frontend/src/components/mainPage/scene/DebugScene.vue
+++ b/frontend/src/components/mainPage/scene/DebugScene.vue
@@ -1,6 +1,6 @@
 <template>
     <v-card elevation="3">
-        <div class="scene-container full-size" v-if="!showLoading">
+        <div class="scene-container full-size" :class="{ hidden: showLoading }">
             <SceneCanvas class="full-size"></SceneCanvas>
 
             <CenterPanel v-if="!this.isRunning" />
@@ -9,7 +9,7 @@
             <NavigationPanel v-if="this.isRunning" />
             <FrameNumberPanel v-if="this.isRunning" />
         </div>
-        <div class="full-size d-flex flex-center flex-column" v-else>
+        <div class="full-size d-flex flex-center flex-column" :class="{ hidden: !showLoading }">
             <v-progress-circular indeterminate color="primary" />
             <span class="mt-3">Trwa kompilacja kodu...</span>
         </div>
@@ -75,5 +75,9 @@
         position: absolute;
         bottom: 0;
         right: 0;
+    }
+
+    .hidden {
+        display: none;
     }
 </style>

--- a/frontend/src/components/mainPage/scene/subcomponents/SceneCanvas.vue
+++ b/frontend/src/components/mainPage/scene/subcomponents/SceneCanvas.vue
@@ -21,6 +21,14 @@
             this.emitter.on("themeChangeEvent", this.draw);
         },
 
+        unmounted() {
+            this.emitter.off("startDebuggingEvent", this.draw);
+            this.emitter.off("currentFrameChangedEvent", this.draw);
+            this.emitter.off("stopDebuggingEvent", this.clearStage);
+            this.emitter.off("downloadStageEvent", this.download);
+            this.emitter.off("themeChangeEvent", this.draw);
+        },
+
         methods: {
             ...mapActions(useProjectStore, ["updateSceneObjectPosition"]),
 


### PR DESCRIPTION
https://trello.com/c/TIAIhW3j/79-bug-podw%C3%B3jne-pobieranie-klatki-animacji

W zasadzie to nie podwójne. Przy uruchomieniu AlgoDebuga tworzony został SceneCanvas, który rejestrował event handlery, ale ich nie usuwał. Każde odpalenie debugowania dodawało kolejny SceneCanvas (którego nie było jako element, ale jego listenery jakoś ciągle go podtrzymywały przy życiu mimo, że unmounted() się wywoływało).
Dodałem poprawne usuwanie listenerów. Zawsze gdy używamy emmiter.on powinniśmy używać emmiter.off.
Dodatkowo fakt, że przy każdym uruchamianiu debugowania na nowo renderowały się:
- SceneCanvas
- CenterPanel
- SceneObjectsPanel
- DownloadPanel
- NavigationPanel
- FrameNumberPanel
Wydawał mi się jakiś nieciekawy... Zamiast v-if i v-else dodałem klasę hidden, żeby CSSem szybko ukrywać to, czego nie chcemy, ale nie zmuszać Vue do ponownego tworzenia tych obiektów. 