### PR TITLE
Poprawienie pobierania animacji (export do PDF)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
                 "mitt": "^3.0.0",
                 "monaco-editor": "^0.34.1",
                 "monaco-editor-vue3": "^0.1.6",
+                "pdfmake": "^0.2.7",
                 "pinia": "^2.0.29",
                 "vue": "^3.2.41",
                 "vue-3-sanitize": "^0.1.4",
@@ -1723,6 +1724,49 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@foliojs-fork/fontkit": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.1.tgz",
+            "integrity": "sha512-U589voc2/ROnvx1CyH9aNzOQWJp127JGU1QAylXGQ7LoEAF6hMmahZLQ4eqAcgHUw+uyW4PjtCItq9qudPkK3A==",
+            "dependencies": {
+                "@foliojs-fork/restructure": "^2.0.2",
+                "brfs": "^2.0.0",
+                "brotli": "^1.2.0",
+                "browserify-optional": "^1.0.1",
+                "clone": "^1.0.4",
+                "deep-equal": "^1.0.0",
+                "dfa": "^1.2.0",
+                "tiny-inflate": "^1.0.2",
+                "unicode-properties": "^1.2.2",
+                "unicode-trie": "^2.0.0"
+            }
+        },
+        "node_modules/@foliojs-fork/linebreak": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.1.tgz",
+            "integrity": "sha512-pgY/+53GqGQI+mvDiyprvPWgkTlVBS8cxqee03ejm6gKAQNsR1tCYCIvN9FHy7otZajzMqCgPOgC4cHdt4JPig==",
+            "dependencies": {
+                "base64-js": "1.3.1",
+                "brfs": "^2.0.2",
+                "unicode-trie": "^2.0.0"
+            }
+        },
+        "node_modules/@foliojs-fork/pdfkit": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.13.0.tgz",
+            "integrity": "sha512-YXeG1fml9k97YNC9K8e292Pj2JzGt9uOIiBFuQFxHsdQ45BlxW+JU3RQK6JAvXU7kjhjP8rCcYvpk36JLD33sQ==",
+            "dependencies": {
+                "@foliojs-fork/fontkit": "^1.9.1",
+                "@foliojs-fork/linebreak": "^1.1.1",
+                "crypto-js": "^4.0.0",
+                "png-js": "^1.0.0"
+            }
+        },
+        "node_modules/@foliojs-fork/restructure": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
+            "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA=="
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.7",
             "dev": true,
@@ -2217,6 +2261,35 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/acorn-node": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+            "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+            "dependencies": {
+                "acorn": "^7.0.0",
+                "acorn-walk": "^7.0.0",
+                "xtend": "^4.0.2"
+            }
+        },
+        "node_modules/acorn-node/node_modules/acorn": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+            "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "dev": true,
@@ -2239,6 +2312,15 @@
             "peer": true,
             "peerDependencies": {
                 "ajv": "^6.9.1"
+            }
+        },
+        "node_modules/amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+            "optional": true,
+            "engines": {
+                "node": ">=0.4.2"
             }
         },
         "node_modules/ansi-regex": {
@@ -2276,6 +2358,29 @@
             "version": "2.0.1",
             "dev": true,
             "license": "Python-2.0"
+        },
+        "node_modules/array-from": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+            "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg=="
+        },
+        "node_modules/ast-transform": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/ast-transform/-/ast-transform-0.0.0.tgz",
+            "integrity": "sha512-e/JfLiSoakfmL4wmTGPjv0HpTICVmxwXgYOB8x+mzozHL8v+dSfCbrJ8J8hJ0YBP0XcYu1aLZ6b/3TnxNK3P2A==",
+            "dependencies": {
+                "escodegen": "~1.2.0",
+                "esprima": "~1.0.4",
+                "through": "~2.3.4"
+            }
+        },
+        "node_modules/ast-types": {
+            "version": "0.7.8",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+            "integrity": "sha512-RIOpVnVlltB6PcBJ5BMLx+H+6JJ/zjDGU0t7f0L6c2M1dqcK92VQopLBlPQ9R80AVXelfqYgjcPLtHtDbNFg0Q==",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -2334,6 +2439,11 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/base64-js": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "dev": true,
@@ -2367,6 +2477,51 @@
                 "node": ">=8"
             }
         },
+        "node_modules/brfs": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brfs/-/brfs-2.0.2.tgz",
+            "integrity": "sha512-IrFjVtwu4eTJZyu8w/V2gxU7iLTtcHih67sgEdzrhjLBMHp2uYefUBfdM4k2UvcuWMgV7PQDZHSLeNWnLFKWVQ==",
+            "dependencies": {
+                "quote-stream": "^1.0.1",
+                "resolve": "^1.1.5",
+                "static-module": "^3.0.2",
+                "through2": "^2.0.0"
+            },
+            "bin": {
+                "brfs": "bin/cmd.js"
+            }
+        },
+        "node_modules/brotli": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+            "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+            "dependencies": {
+                "base64-js": "^1.1.2"
+            }
+        },
+        "node_modules/browser-resolve": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+            "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+            "dependencies": {
+                "resolve": "1.1.7"
+            }
+        },
+        "node_modules/browser-resolve/node_modules/resolve": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+            "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg=="
+        },
+        "node_modules/browserify-optional": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-optional/-/browserify-optional-1.0.1.tgz",
+            "integrity": "sha512-VrhjbZ+Ba5mDiSYEuPelekQMfTbhcA2DhLk2VQWqdcCROWeFqlTcXZ7yfRkXCIl8E+g4gINJYJiRB7WEtfomAQ==",
+            "dependencies": {
+                "ast-transform": "0.0.0",
+                "ast-types": "^0.7.0",
+                "browser-resolve": "^1.8.1"
+            }
+        },
         "node_modules/browserslist": {
             "version": "4.21.4",
             "dev": true,
@@ -2394,11 +2549,29 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
+        "node_modules/buffer-equal": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+            "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/buffer-from": {
             "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -2482,6 +2655,14 @@
                 "node": ">=6.0"
             }
         },
+        "node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/color-convert": {
             "version": "1.9.3",
             "dev": true,
@@ -2510,11 +2691,23 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "engines": [
+                "node >= 0.8"
+            ],
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/core-js": {
             "version": "3.26.0",
@@ -2537,6 +2730,11 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
             }
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
         },
         "node_modules/cors": {
             "version": "2.8.5",
@@ -2562,6 +2760,11 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/crypto-js": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+            "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+        },
         "node_modules/cssesc": {
             "version": "3.0.0",
             "dev": true,
@@ -2576,6 +2779,20 @@
         "node_modules/csstype": {
             "version": "2.6.21",
             "license": "MIT"
+        },
+        "node_modules/d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dependencies": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
+        "node_modules/dash-ast": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-2.0.1.tgz",
+            "integrity": "sha512-5TXltWJGc+RdnabUGzhRae1TRq6m4gr+3K2wQX0is5/F2yS6MJXJvLyI3ErAnsAXuJoGqvfVD5icRgim07DrxQ=="
         },
         "node_modules/debug": {
             "version": "4.3.4",
@@ -2593,9 +2810,24 @@
                 }
             }
         },
+        "node_modules/deep-equal": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+            "dependencies": {
+                "is-arguments": "^1.0.4",
+                "is-date-object": "^1.0.1",
+                "is-regex": "^1.0.4",
+                "object-is": "^1.0.1",
+                "object-keys": "^1.1.1",
+                "regexp.prototype.flags": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/deepmerge": {
@@ -2605,12 +2837,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/define-properties": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+            "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+            "dependencies": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
+        },
+        "node_modules/dfa": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+            "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
@@ -2670,6 +2922,14 @@
                 "url": "https://github.com/fb55/domutils?sponsor=1"
             }
         },
+        "node_modules/duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dependencies": {
+                "readable-stream": "^2.0.2"
+            }
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.4.284",
             "dev": true,
@@ -2700,6 +2960,73 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/es5-ext": {
+            "version": "0.10.62",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+            "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.3",
+                "next-tick": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "node_modules/es6-map": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+            "integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "~0.10.14",
+                "es6-iterator": "~2.0.1",
+                "es6-set": "~0.1.5",
+                "es6-symbol": "~3.1.1",
+                "event-emitter": "~0.3.5"
+            }
+        },
+        "node_modules/es6-set": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.6.tgz",
+            "integrity": "sha512-TE3LgGLDIBX332jq3ypv6bcOpkLO0AslAQo7p2VqX/1N46YNsvIWgvjojjSEnWEGWMhr1qUbYeTSir5J6mFHOw==",
+            "dependencies": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.62",
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "^3.1.3",
+                "event-emitter": "^0.3.5",
+                "type": "^2.7.2"
+            },
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/es6-set/node_modules/type": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+            "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+        },
+        "node_modules/es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dependencies": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
         },
         "node_modules/esbuild": {
             "version": "0.16.17",
@@ -2749,6 +3076,54 @@
             "version": "1.0.5",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/escodegen": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.2.0.tgz",
+            "integrity": "sha512-yLy3Cc+zAC0WSmoT2fig3J87TpQ8UaZGx8ahCAs9FL8qNbyV7CVyPKS74DG4bsHiL5ew9sxdYx131OkBQMFnvA==",
+            "dependencies": {
+                "esprima": "~1.0.4",
+                "estraverse": "~1.5.0",
+                "esutils": "~1.0.0"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.1.30"
+            }
+        },
+        "node_modules/escodegen/node_modules/estraverse": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+            "integrity": "sha512-FpCjJDfmo3vsc/1zKSeqR5k42tcIhxFIlvq+h9j0fO2q/h2uLKyweq7rYJ+0CoVvrGQOxIS5wyBrW/+vF58BUQ==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/escodegen/node_modules/esutils": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+            "integrity": "sha512-x/iYH53X3quDwfHRz4y8rn4XcEwwCJeWsul9pF1zldMbGtgOtMNBEOuYWwB1EQlK2LRa1fev3YAgym/RElp5Cg==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/escodegen/node_modules/source-map": {
+            "version": "0.1.43",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+            "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+            "optional": true,
+            "dependencies": {
+                "amdefine": ">=0.0.4"
+            },
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -3011,6 +3386,18 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/esprima": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+            "integrity": "sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA==",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/esquery": {
             "version": "1.4.0",
             "dev": true,
@@ -3041,16 +3428,29 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-is-function": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/estree-is-function/-/estree-is-function-1.0.0.tgz",
+            "integrity": "sha512-nSCWn1jkSq2QAtkaVLJZY2ezwcFO161HVc174zL1KPW3RJ+O6C3eJb8Nx7OXzvhoEv+nLgSR1g71oWUHUDTrJA=="
+        },
         "node_modules/estree-walker": {
             "version": "2.0.2",
             "license": "MIT"
         },
         "node_modules/esutils": {
             "version": "2.0.3",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "node_modules/events": {
@@ -3061,6 +3461,19 @@
             "engines": {
                 "node": ">=0.8.x"
             }
+        },
+        "node_modules/ext": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+            "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+            "dependencies": {
+                "type": "^2.7.2"
+            }
+        },
+        "node_modules/ext/node_modules/type": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+            "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -3074,7 +3487,6 @@
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fastq": {
@@ -3176,8 +3588,15 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.1",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/functions-have-names": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
@@ -3186,6 +3605,24 @@
             "peer": true,
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/get-assigned-identifiers": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+            "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ=="
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+            "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/glob": {
@@ -3245,7 +3682,6 @@
         },
         "node_modules/has": {
             "version": "1.0.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.1"
@@ -3260,6 +3696,42 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "dependencies": {
+                "get-intrinsic": "^1.1.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/htmlparser2": {
@@ -3277,6 +3749,17 @@
                 "domhandler": "^4.0.0",
                 "domutils": "^2.5.2",
                 "entities": "^2.0.0"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/ignore": {
@@ -3326,8 +3809,22 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
-            "dev": true,
             "license": "ISC"
+        },
+        "node_modules/is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -3342,10 +3839,23 @@
         },
         "node_modules/is-core-module": {
             "version": "2.11.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-date-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -3391,6 +3901,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-regex": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/isarray": {
@@ -3619,6 +4144,22 @@
                 "sourcemap-codec": "^1.4.8"
             }
         },
+        "node_modules/merge-source-map": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+            "integrity": "sha512-PGSmS0kfnTnMJCzJ16BLLCEe6oeYCamKFFdQKshi4BmM6FUwipjVOcBFGxqtQtirtAG4iZvHlqST9CpZKqlRjA==",
+            "dependencies": {
+                "source-map": "^0.5.6"
+            }
+        },
+        "node_modules/merge-source-map/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "dev": true,
@@ -3651,6 +4192,14 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/mitt": {
@@ -3699,6 +4248,11 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/next-tick": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+            "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+        },
         "node_modules/node-releases": {
             "version": "2.0.6",
             "dev": true,
@@ -3728,6 +4282,37 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.12.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-is": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/once": {
@@ -3782,6 +4367,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pako": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+            "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "dev": true,
@@ -3823,8 +4413,21 @@
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/pdfmake": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.7.tgz",
+            "integrity": "sha512-ClLpgx30H5G3EDvRW1MrA1Xih6YxEaSgIVFrOyBMgAAt62V+hxsyWAi6JNP7u1Fc5JKYAbpb4RRVw8Rhvmz5cQ==",
+            "dependencies": {
+                "@foliojs-fork/linebreak": "^1.1.1",
+                "@foliojs-fork/pdfkit": "^0.13.0",
+                "iconv-lite": "^0.6.3",
+                "xmldoc": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/picocolors": {
             "version": "1.0.0",
@@ -3891,6 +4494,11 @@
                 }
             }
         },
+        "node_modules/png-js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+            "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
+        },
         "node_modules/postcss": {
             "version": "8.4.21",
             "funding": [
@@ -3947,6 +4555,11 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "license": "MIT"
@@ -3978,6 +4591,19 @@
             ],
             "license": "MIT"
         },
+        "node_modules/quote-stream": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+            "integrity": "sha512-kKr2uQ2AokadPjvTyKJQad9xELbZwYzWlNfI3Uz2j/ib5u6H9lDP7fUUR//rMycd0gv4Z5P1qXMfXR8YpIxrjQ==",
+            "dependencies": {
+                "buffer-equal": "0.0.1",
+                "minimist": "^1.1.3",
+                "through2": "^2.0.0"
+            },
+            "bin": {
+                "quote-stream": "bin/cmd.js"
+            }
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "dev": true,
@@ -3986,6 +4612,25 @@
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
+        },
+        "node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
@@ -4029,6 +4674,22 @@
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.8.4"
+            }
+        },
+        "node_modules/regexp.prototype.flags": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+            "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "functions-have-names": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/regexpp": {
@@ -4088,7 +4749,6 @@
         },
         "node_modules/resolve": {
             "version": "1.22.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.9.0",
@@ -4190,6 +4850,11 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
         "node_modules/sanitize-html": {
             "version": "2.7.3",
             "license": "MIT",
@@ -4265,6 +4930,11 @@
                 }
             }
         },
+        "node_modules/sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
         "node_modules/schema-utils": {
             "version": "3.1.1",
             "dev": true,
@@ -4283,6 +4953,20 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/scope-analyzer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/scope-analyzer/-/scope-analyzer-2.1.2.tgz",
+            "integrity": "sha512-5cfCmsTYV/wPaRIItNxatw02ua/MThdIUNnUOCYp+3LSEJvnG804ANw2VLaavNILIfWXF1D1G2KNANkBBvInwQ==",
+            "dependencies": {
+                "array-from": "^2.1.1",
+                "dash-ast": "^2.0.1",
+                "es6-map": "^0.1.5",
+                "es6-set": "^0.1.5",
+                "es6-symbol": "^3.1.1",
+                "estree-is-function": "^1.0.0",
+                "get-assigned-identifiers": "^1.1.0"
+            }
+        },
         "node_modules/semver": {
             "version": "6.3.0",
             "dev": true,
@@ -4299,6 +4983,11 @@
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
+        },
+        "node_modules/shallow-copy": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+            "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -4347,6 +5036,232 @@
             "version": "1.4.8",
             "license": "MIT"
         },
+        "node_modules/static-eval": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
+            "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
+            "dependencies": {
+                "escodegen": "^1.11.1"
+            }
+        },
+        "node_modules/static-eval/node_modules/escodegen": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=4.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
+            }
+        },
+        "node_modules/static-eval/node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/static-eval/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/static-eval/node_modules/levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+            "dependencies": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/static-eval/node_modules/optionator": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "dependencies": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/static-eval/node_modules/prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/static-eval/node_modules/type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+            "dependencies": {
+                "prelude-ls": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/static-module": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.4.tgz",
+            "integrity": "sha512-gb0v0rrgpBkifXCa3yZXxqVmXDVE+ETXj6YlC/jt5VzOnGXR2C15+++eXuMDUYsePnbhf+lwW0pE1UXyOLtGCw==",
+            "dependencies": {
+                "acorn-node": "^1.3.0",
+                "concat-stream": "~1.6.0",
+                "convert-source-map": "^1.5.1",
+                "duplexer2": "~0.1.4",
+                "escodegen": "^1.11.1",
+                "has": "^1.0.1",
+                "magic-string": "0.25.1",
+                "merge-source-map": "1.0.4",
+                "object-inspect": "^1.6.0",
+                "readable-stream": "~2.3.3",
+                "scope-analyzer": "^2.0.1",
+                "shallow-copy": "~0.0.1",
+                "static-eval": "^2.0.5",
+                "through2": "~2.0.3"
+            }
+        },
+        "node_modules/static-module/node_modules/escodegen": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=4.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
+            }
+        },
+        "node_modules/static-module/node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/static-module/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/static-module/node_modules/levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+            "dependencies": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/static-module/node_modules/magic-string": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
+            "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+            "dependencies": {
+                "sourcemap-codec": "^1.4.1"
+            }
+        },
+        "node_modules/static-module/node_modules/optionator": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "dependencies": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/static-module/node_modules/prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/static-module/node_modules/type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+            "dependencies": {
+                "prelude-ls": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "dev": true,
@@ -4382,7 +5297,6 @@
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -4463,6 +5377,25 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+        },
+        "node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
+        "node_modules/tiny-inflate": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+        },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
             "dev": true,
@@ -4482,6 +5415,11 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "dev": true,
@@ -4492,6 +5430,11 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -4524,6 +5467,15 @@
                 "node": ">=4"
             }
         },
+        "node_modules/unicode-properties": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+            "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+            "dependencies": {
+                "base64-js": "^1.3.0",
+                "unicode-trie": "^2.0.0"
+            }
+        },
         "node_modules/unicode-property-aliases-ecmascript": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
@@ -4531,6 +5483,15 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/unicode-trie": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+            "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+            "dependencies": {
+                "pako": "^0.2.5",
+                "tiny-inflate": "^1.0.0"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -4568,7 +5529,6 @@
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/vary": {
@@ -4894,7 +5854,6 @@
         },
         "node_modules/word-wrap": {
             "version": "1.2.3",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -4911,6 +5870,22 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/xmldoc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.2.0.tgz",
+            "integrity": "sha512-2eN8QhjBsMW2uVj7JHLHkMytpvGHLHxKXBy4J3fAT/HujsEtM6yU84iGjpESYGHg6XwK0Vu4l+KgqQ2dv2cCqg==",
+            "dependencies": {
+                "sax": "^1.2.4"
+            }
+        },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "engines": {
+                "node": ">=0.4"
             }
         },
         "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
         "mitt": "^3.0.0",
         "monaco-editor": "^0.34.1",
         "monaco-editor-vue3": "^0.1.6",
+        "pdfmake": "^0.2.7",
         "pinia": "^2.0.29",
         "vue": "^3.2.41",
         "vue-3-sanitize": "^0.1.4",

--- a/frontend/src/components/mainPage/scene/subcomponents/DownloadPanel.vue
+++ b/frontend/src/components/mainPage/scene/subcomponents/DownloadPanel.vue
@@ -1,18 +1,28 @@
 <template>
     <div class="download-panel-container">
-        <v-btn icon elevation="0" @click="download">
+        <v-btn icon elevation="0" @click="openDownloadFormatModal">
             <v-icon> mdi-download </v-icon>
         </v-btn>
     </div>
 </template>
 
 <script>
+    import { pushModal } from "jenesius-vue-modal";
     import { defineComponent } from "vue";
+    import DownloadSceneModal from "../../../modals/downloading/DownloadSceneModal.vue";
 
     export default defineComponent({
         methods: {
-            download() {
-                this.emitter.emit("downloadStageEvent");
+            openDownloadFormatModal() {
+                pushModal(DownloadSceneModal, {
+                    callback: (format) => {
+                        this.download(format);
+                    },
+                });
+            },
+
+            download(format) {
+                this.emitter.emit("downloadStageEvent", format);
             },
         },
     });

--- a/frontend/src/components/mainPage/scene/subcomponents/SceneCanvas.vue
+++ b/frontend/src/components/mainPage/scene/subcomponents/SceneCanvas.vue
@@ -9,6 +9,7 @@
     import { defineComponent } from "vue";
     import { useProjectStore } from "@/stores/project";
     import { mapActions, mapState } from "pinia";
+    import { exportToPNG, exportToPDF } from "@/javascript/utils/downloadUtils";
 
     export default defineComponent({
         mounted() {
@@ -34,8 +35,12 @@
                 this.stage.clearStage();
             },
 
-            download() {
-                this.stage.downloadImage();
+            download(format) {
+                if (format == "PNG") {
+                    exportToPNG(this.stage);
+                } else if (format == "PDF") {
+                    exportToPDF(this.stage);
+                }
             },
         },
 

--- a/frontend/src/components/modals/downloading/DownloadSceneModal.vue
+++ b/frontend/src/components/modals/downloading/DownloadSceneModal.vue
@@ -1,0 +1,25 @@
+<template>
+    <AlgoModal title="Wybierz format zapisu">
+        <v-btn @click="handleDownloadOption('PNG')">PNG (jedna klatka)</v-btn>
+        <v-btn @click="handleDownloadOption('PDF')">PDF (wszystkie klatki)</v-btn>
+    </AlgoModal>
+</template>
+
+<script>
+    import AlgoModal from "@/components/global/AlgoModal.vue";
+    import { popModal } from "jenesius-vue-modal";
+    import { defineComponent } from "vue";
+
+    export default defineComponent({
+        components: { AlgoModal },
+
+        props: ["callback"],
+
+        methods: {
+            handleDownloadOption(selectedOption) {
+                this.$props.callback(selectedOption);
+                popModal();
+            },
+        },
+    });
+</script>

--- a/frontend/src/components/modals/downloading/DownloadSceneModal.vue
+++ b/frontend/src/components/modals/downloading/DownloadSceneModal.vue
@@ -1,7 +1,9 @@
 <template>
     <AlgoModal title="Wybierz format zapisu">
-        <v-btn @click="handleDownloadOption('PNG')">PNG (jedna klatka)</v-btn>
-        <v-btn @click="handleDownloadOption('PDF')">PDF (wszystkie klatki)</v-btn>
+        <div class="flex-center">
+            <v-btn @click="handleDownloadOption('PNG')" class="download-button">PNG (jedna klatka)</v-btn>
+            <v-btn @click="handleDownloadOption('PDF')" class="download-button">PDF (wszystkie klatki)</v-btn>
+        </div>
     </AlgoModal>
 </template>
 
@@ -23,3 +25,9 @@
         },
     });
 </script>
+
+<style scoped>
+    .download-button {
+        margin: 5px 15px;
+    }
+</style>

--- a/frontend/src/javascript/stage/Stage.js
+++ b/frontend/src/javascript/stage/Stage.js
@@ -89,14 +89,8 @@ export class Stage {
         this.stage.find("Group").forEach((layer) => layer.destroy());
     }
 
-    downloadImage() {
-        let uri = this.stage.toDataURL({ pixelRatio: 3 });
-        let link = document.createElement("a");
-        link.download = "algodebug.jpeg";
-        link.href = uri;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+    getBase64Image() {
+        return this.stage.toDataURL({ pixelRatio: 2 });
     }
 
     getCanvasSize() {

--- a/frontend/src/javascript/utils/downloadUtils.js
+++ b/frontend/src/javascript/utils/downloadUtils.js
@@ -43,7 +43,7 @@ function downloadFile(name, uri) {
 function getSafeProjectFilename(extension) {
     const projectStore = useProjectStore();
     let projectTitle = projectStore.projectTitle;
-    projectTitle = projectTitle.replace(/[^a-z0-9]/gi, "_").replace(/_{2,}/g, "_");
+    projectTitle = projectTitle.replace(/[^a-z0-9żźćńółęąś]/gi, "_").replace(/_{2,}/g, "_");
     projectTitle = projectTitle.substring(0, 200);
     return projectTitle + "." + extension;
 }

--- a/frontend/src/javascript/utils/downloadUtils.js
+++ b/frontend/src/javascript/utils/downloadUtils.js
@@ -1,0 +1,68 @@
+import * as pdfMake from "pdfmake/build/pdfmake";
+import { useProjectStore } from "@/stores/project";
+import { getCurrentThemeFromStorage } from "@/javascript/storage/themeStorage";
+
+export function exportToPDF(stage) {
+    const projectStore = useProjectStore();
+    var documentDefinition = getBlankPDFDocumentDefinition();
+    const drawableWidth = documentDefinition.pageSize.width - 2 * documentDefinition.pageMargins[0];
+    const drawableHeight = documentDefinition.pageSize.height - 2 * documentDefinition.pageMargins[1];
+
+    for (let frame of projectStore.allFrames) {
+        stage.draw(projectStore.sceneObjects, frame, projectStore.updateSceneObjectPosition);
+        documentDefinition.images["frame_" + frame.id] = stage.getBase64Image();
+        documentDefinition.content.push({
+            image: "frame_" + frame.id,
+            fit: [drawableWidth, drawableHeight],
+            pageBreak: "after",
+        });
+    }
+    stage.draw(projectStore.sceneObjects, projectStore.currentFrame, projectStore.updateSceneObjectPosition);
+
+    if (documentDefinition.content.length > 0) {
+        documentDefinition.content[documentDefinition.content.length - 1].pageBreak = undefined;
+    }
+
+    pdfMake.createPdf(documentDefinition).download("algodebug.pdf");
+}
+
+export function exportToPNG(stage) {
+    let uri = stage.getBase64Image();
+    downloadFile("algodebug.png", uri);
+}
+
+function downloadFile(name, uri) {
+    let link = document.createElement("a");
+    link.download = name;
+    link.href = uri;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+}
+
+function getBlankPDFDocumentDefinition() {
+    return {
+        pageSize: {
+            width: 595.28,
+            height: 841.89,
+        },
+        pageMargins: [20, 30],
+        background: function () {
+            if (getCurrentThemeFromStorage() === "light") return;
+            return {
+                canvas: [
+                    {
+                        type: "rect",
+                        x: 0,
+                        y: 0,
+                        w: 595.28,
+                        h: 841.89,
+                        color: "#212121",
+                    },
+                ],
+            };
+        },
+        content: [],
+        images: {},
+    };
+}

--- a/frontend/src/javascript/utils/downloadUtils.js
+++ b/frontend/src/javascript/utils/downloadUtils.js
@@ -23,12 +23,12 @@ export function exportToPDF(stage) {
         documentDefinition.content[documentDefinition.content.length - 1].pageBreak = undefined;
     }
 
-    pdfMake.createPdf(documentDefinition).download("algodebug.pdf");
+    pdfMake.createPdf(documentDefinition).download(getSafeProjectFilename("pdf"));
 }
 
 export function exportToPNG(stage) {
     let uri = stage.getBase64Image();
-    downloadFile("algodebug.png", uri);
+    downloadFile(getSafeProjectFilename("png"), uri);
 }
 
 function downloadFile(name, uri) {
@@ -38,6 +38,14 @@ function downloadFile(name, uri) {
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+}
+
+function getSafeProjectFilename(extension) {
+    const projectStore = useProjectStore();
+    let projectTitle = projectStore.projectTitle;
+    projectTitle = projectTitle.replace(/[^a-z0-9]/gi, "_").replace(/_{2,}/g, "_");
+    projectTitle = projectTitle.substring(0, 200);
+    return projectTitle + "." + extension;
 }
 
 function getBlankPDFDocumentDefinition() {

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -77,6 +77,10 @@ export const useProjectStore = defineStore("project", {
                 inputs: this.testData.map((testCase) => testCase.input),
             };
         },
+
+        projectTitle() {
+            return this.title;
+        },
     },
 
     actions: {

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -52,6 +52,10 @@ export const useProjectStore = defineStore("project", {
             return this.currentTestCase.frames.length;
         },
 
+        allFrames() {
+            return this.currentTestCase.frames;
+        },
+
         jsonForSave() {
             return (override, title = null) => {
                 let result = {


### PR DESCRIPTION
https://trello.com/c/7W4aI0w5/5-poprawienie-pobierania-animacji

Niestety, jest to dosyć wolne. Sprawdzałem różne biblioteki do PDFów i wszystkie zajmują dość długo (inny PR naprawia bug z wielokrotnym pobieraniem, więc przed testowaniem tego zalecam zmergować tamten).
Głównym powodem wydaje się być wielkość wyjściowych obrazów. Zmniejszyłem ich jakość z 3 do 2 punktów, trochę pomogło. 
Fajnie byłoby do każdej opcji exportu dodać okienko z opcjami (marginesy, kolory, jakość, etc.)
Modal wyboru typu zapisu jest do ulepszenia, trochę roboczo wrzuciłem po prostu dwa buttony i nic ładniejszego nie skleiłem.