### PR TITLE
[Bug] Nie da się zmienić tytułu przy zapisie

### DIFF
--- a/frontend/src/components/modals/menu/SaveProjectModal.vue
+++ b/frontend/src/components/modals/menu/SaveProjectModal.vue
@@ -14,7 +14,7 @@
     import { closeModal } from "jenesius-vue-modal";
     import { defineComponent } from "vue";
     import { useProjectStore } from "@/stores/project";
-    import { mapActions, mapState } from "pinia";
+    import { mapActions, mapWritableState } from "pinia";
 
     export default defineComponent({
         components: { AlgoModal },
@@ -29,7 +29,7 @@
         },
 
         computed: {
-            ...mapState(useProjectStore, ["title", "_id"]),
+            ...mapWritableState(useProjectStore, ["title", "_id"]),
         },
     });
 </script>

--- a/frontend/src/components/modals/menu/SaveProjectModal.vue
+++ b/frontend/src/components/modals/menu/SaveProjectModal.vue
@@ -1,6 +1,6 @@
 <template>
     <AlgoModal title="Zapisz projekt">
-        <v-text-field label="Tytuł projektu" v-model="title" clearable />
+        <v-text-field label="Tytuł projektu" v-model="tempTitle" clearable />
 
         <template #buttons>
             <v-btn color="primary" @click="save(false)">Zapisz jako</v-btn>
@@ -14,22 +14,33 @@
     import { closeModal } from "jenesius-vue-modal";
     import { defineComponent } from "vue";
     import { useProjectStore } from "@/stores/project";
-    import { mapActions, mapWritableState } from "pinia";
+    import { mapActions, mapState } from "pinia";
 
     export default defineComponent({
         components: { AlgoModal },
+
+        data() {
+            return {
+                tempTitle: "",
+            };
+        },
+
+        mounted() {
+            this.tempTitle = this.title;
+        },
 
         methods: {
             ...mapActions(useProjectStore, ["saveProject"]),
 
             save(override) {
-                this.saveProject(this.title, override);
+                if (override) this.saveProject(this.title, true);
+                else this.saveProject(this.tempTitle, false);
                 closeModal();
             },
         },
 
         computed: {
-            ...mapWritableState(useProjectStore, ["title", "_id"]),
+            ...mapState(useProjectStore, ["title", "_id"]),
         },
     });
 </script>

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -149,10 +149,10 @@ export const useProjectStore = defineStore("project", {
         },
 
         saveProject(title, override) {
+            this.title = title;
             sendRequest("/project/save", this.jsonForSave(override, title), override ? "PUT" : "POST").then(
                 (responseData) => {
-                    this.id = responseData.id;
-                    this.title = responseData.title;
+                    this._id = responseData.insertedId;
                 }
             );
         },


### PR DESCRIPTION
https://trello.com/c/MCjAepz0/97-bug-nie-da-si%C4%99-zmieni%C4%87-tytu%C5%82u-przy-zapisie

Opis: Coś bardzo złego się stało z zapisywaniem do bazy. Z moich obserwacji pole "tytuł" do zapisu jest readonly (leci warning przy wklepywaniu w konsoli) i się nie updatuje. Przez to, jeśli projekt jest wczytany z tytułem to save as zapisze pod tym samym tytułem co pierwotny (zrobiłem nawet test na mikrusie, pojawiło się nowe GCD mimo innej nazwy wpisanej), a jeśli został stworzony a nie wczytany i jego title jest puste, to backend zwróci błąd

Rozwiązanie widać w diffie, pinia musi używać `mapWritableState`, inaczej jest tylko readonly.