### PR TITLE
[Bug] Linia z aktualnym breakpointem nie koloruje się

### DIFF
--- a/frontend/src/components/mainPage/codeEditor/CodeEditor.vue
+++ b/frontend/src/components/mainPage/codeEditor/CodeEditor.vue
@@ -144,7 +144,7 @@
         },
 
         computed: {
-            ...mapState(useProjectStore, ["variables", "currentFrame", "breakpoints"]),
+            ...mapState(useProjectStore, ["variables", "currentFrame", "breakpoints", "isRunning"]),
             ...mapState(useProjectStore, { projectCode: (state) => state.code }),
 
             modelCode: {


### PR DESCRIPTION
https://trello.com/c/zIMT0EII/96-bug-linia-z-aktualnym-breakpointem-nie-koloruje-si%C4%99

Zgaduję, że popsuło się przy migrowaniu do Pinii, bo "isRunning" nie było zmapowane (co zabawne, getBreakpointClass zdawał się tym nie przejmować, bo to działało dobrze).