### PR TITLE
Dodanie opcji w menu kontekstowym edytora do szybkiego tworzenia obiektu scenicznego śledzącego daną zmienną

### DIFF
--- a/frontend/src/components/mainPage/codeEditor/CodeEditor.vue
+++ b/frontend/src/components/mainPage/codeEditor/CodeEditor.vue
@@ -1,290 +1,55 @@
-<template>
-    <div :id="id" class="code-editor-container">
-        <slot></slot>
-        <MonacoEditor
-            :id="id"
-            v-model:value="modelCode"
-            :options="options"
-            @editorDidMount="editorDidMount"
-        ></MonacoEditor>
-    </div>
-</template>
-
 <script>
-    import MonacoEditor from "monaco-editor-vue3";
-    import * as monaco from "monaco-editor/esm/vs/editor/editor.main";
-    import {
-        getVariablesArray,
-        monacoChangeToLegacyFormat,
-        moveBreakpoints,
-        moveTrackedVariables,
-    } from "@/javascript/utils/codeUtils";
-    import lineColumn from "line-column";
     import { defineComponent } from "vue";
-    import { getCurrentThemeFromStorage } from "@/javascript/storage/themeStorage";
+    import CodeViewer from "./CodeViewer.vue";
+    import { pushModal } from "jenesius-vue-modal";
+    import ConfigureSceneObjectModal from "@/components/modals/sceneObject/ConfigureSceneObjectModal.vue";
+    import { KeyMod, KeyCode } from "monaco-editor/esm/vs/editor/editor.main";
+    import { mapActions } from "pinia";
     import { useProjectStore } from "@/stores/project";
-    import { mapActions, mapState } from "pinia";
 
     export default defineComponent({
-        components: { MonacoEditor },
-        props: ["id", "code", "editable", "clickable", "showHighlightedVariables", "showBreakpoints"],
-
-        data() {
-            return {
-                options: {
-                    language: "cpp",
-                    theme: this.getEditorTheme(),
-                    automaticLayout: "true",
-                    readOnly: !this.$props.editable,
-                    minimap: { enabled: false },
-                    colorDecorators: true,
-                    glyphMargin: true,
-                },
-
-                currentVariablesDecorations: [],
-                currentBreakpointsDecorations: [],
-                currentLineDecorations: [],
-                currentTargetDecorations: [],
-            };
-        },
+        extends: CodeViewer,
 
         mounted() {
-            this.updateAllDecorations();
-            this.emitter.on("themeChangeEvent", () => {
-                this.options.theme = this.getEditorTheme();
+            this.editor.addAction({
+                id: "fast-add-sceneobject",
+                label: "Śledź zmienną",
+                keybindings: [KeyMod.CtrlCmd | KeyCode.F10],
+
+                contextMenuGroupId: "navigation",
+
+                run: () => {
+                    const variable = this.getVariableInPosition(this.editor.getPosition());
+                    const sceneObject = {
+                        type: "variable",
+                        variable: variable,
+                        converter: null,
+                        subobjects: [],
+                    };
+
+                    this.addSceneObject(sceneObject);
+                },
+            });
+
+            this.editor.addAction({
+                id: "add-sceneobject",
+                label: "Nowy obiekt sceniczny",
+                keybindings: [KeyMod.CtrlCmd | KeyCode.F11],
+
+                contextMenuGroupId: "navigation",
+
+                run: () => {
+                    const variable = this.getVariableInPosition(this.editor.getPosition());
+
+                    pushModal(ConfigureSceneObjectModal, {
+                        variable: variable,
+                    });
+                },
             });
         },
 
         methods: {
-            ...mapActions(useProjectStore, ["setCode", "toggleBreakpoint"]),
-
-            editorDidMount(editor) {
-                this.editor = editor;
-
-                editor.getModel().onDidChangeContent((event) => {
-                    this.handleChangeContent(event);
-                });
-
-                editor.onMouseDown((event) => {
-                    this.handleClick(event);
-                });
-            },
-
-            getEditorTheme() {
-                if (getCurrentThemeFromStorage() === "light") return "vs-light";
-                return "vs-dark";
-            },
-
-            handlePickVariable(event) {
-                const word = this.editor.getModel().getWordAtPosition(event.target.position);
-                const variable = {
-                    id: event.target.element.innerText,
-                    name: event.target.element.innerText,
-                    start: lineColumn(this.$props.code).toIndex(event.target.position.lineNumber, word.startColumn),
-                    end: lineColumn(this.$props.code).toIndex(event.target.position.lineNumber, word.endColumn),
-                };
-                this.$emit("pickVariableEvent", variable);
-            },
-
-            handleChangeContent(event) {
-                for (let change of event.changes) {
-                    // change.forceMoveMarkers is undefined when text is changed by code.
-                    // We must update decorations manually, because otherwise it doesn't show up on startup
-                    if (change.forceMoveMarkers === undefined) {
-                        this.updateAllDecorations();
-                        break;
-                    }
-                }
-
-                const legacyChanges = event.changes
-                    .filter((ch) => ch.forceMoveMarkers != undefined)
-                    .map((ch) => monacoChangeToLegacyFormat(this.$props.code, ch));
-
-                moveTrackedVariables(this.variables, legacyChanges, this.projectCode);
-                moveBreakpoints(this.breakpoints, legacyChanges);
-            },
-
-            handleClick(event) {
-                if (event.target.element.classList.contains("breakpoint")) {
-                    if (!this.$props.editable) return;
-                    this.toggleBreakpoint(event.target.position.lineNumber - 1);
-                    return;
-                }
-
-                if (event.target.element.classList.contains("target")) {
-                    this.handlePickVariable(event);
-                }
-            },
-
-            updateAllDecorations() {
-                this.updateVariablesDecorations(this.variablesDecorations);
-                this.updateBreakpointsDecorations(this.breakpointsDecorations);
-                this.updateLineDecorations(this.lineDecorations);
-                this.updateTargetDecorations(this.targetDecorations);
-            },
-
-            updateVariablesDecorations(dec) {
-                this.currentVariablesDecorations = this.editor.deltaDecorations(this.currentVariablesDecorations, dec);
-            },
-
-            updateBreakpointsDecorations(dec) {
-                this.currentBreakpointsDecorations = this.editor.deltaDecorations(
-                    this.currentBreakpointsDecorations,
-                    dec
-                );
-            },
-
-            updateLineDecorations(dec) {
-                this.currentLineDecorations = this.editor.deltaDecorations(this.currentLineDecorations, dec);
-            },
-
-            updateTargetDecorations(dec) {
-                this.currentTargetDecorations = this.editor.deltaDecorations(this.currentTargetDecorations, dec);
-            },
-        },
-
-        computed: {
-            ...mapState(useProjectStore, ["variables", "currentFrame", "breakpoints"]),
-            ...mapState(useProjectStore, { projectCode: (state) => state.code }),
-
-            modelCode: {
-                get() {
-                    return this.$props.code;
-                },
-                set(newValue) {
-                    this.setCode(newValue);
-                },
-            },
-
-            variablesDecorations() {
-                if (!this.$props.showHighlightedVariables) return [];
-
-                return this.variables.map((variable) => {
-                    let startLineColumn = lineColumn(this.$props.code, variable.start);
-                    let endLineColumn = lineColumn(this.$props.code, variable.end);
-                    return {
-                        range: new monaco.Range(
-                            startLineColumn.line,
-                            startLineColumn.col,
-                            endLineColumn.line,
-                            endLineColumn.col
-                        ),
-                        options: { inlineClassName: "highlight-variable" },
-                    };
-                });
-            },
-
-            breakpointsDecorations() {
-                if (!this.$props.showBreakpoints) return [];
-
-                return this.$props.code.split("\n").map((_, i) => {
-                    return {
-                        range: new monaco.Range(i + 1, 1, i + 1, 1),
-                        options: {
-                            glyphMarginClassName: this.getBreakpointClass(i),
-                        },
-                    };
-                });
-            },
-
-            lineDecorations() {
-                if (!this.$props.showHighlightedVariables) return [];
-                if (!this.isRunning) return [];
-
-                return [
-                    {
-                        range: new monaco.Range(this.currentFrame?.line + 1, 1, this.currentFrame?.line + 1, 1),
-                        options: { isWholeLine: true, className: "highlight-line" },
-                    },
-                ];
-            },
-
-            targetDecorations() {
-                if (!this.$props.clickable) return [];
-
-                return getVariablesArray(this.language, this.$props.code).map((word) => {
-                    return {
-                        range: new monaco.Range(
-                            word.startLineNumber,
-                            word.startColumn,
-                            word.endLineNumber,
-                            word.endColumn
-                        ),
-                        options: { inlineClassName: "target" },
-                    };
-                });
-            },
-
-            getBreakpointClass() {
-                return (i) => {
-                    if (this.breakpoints.hasId(i)) return "breakpoint breakpoint-active";
-                    if (!this.isRunning && this.$props.editable) return "breakpoint";
-                    return "";
-                };
-            },
-        },
-
-        watch: {
-            editable: function (newVal) {
-                this.options.readOnly = !newVal;
-                this.editor.updateOptions({ readOnly: !newVal });
-            },
-
-            variablesDecorations: function (dec) {
-                this.updateVariablesDecorations(dec);
-            },
-
-            breakpointsDecorations: function (dec) {
-                this.updateBreakpointsDecorations(dec);
-            },
-
-            lineDecorations: function (dec) {
-                this.updateLineDecorations(dec);
-            },
+            ...mapActions(useProjectStore, ["addSceneObject"]),
         },
     });
 </script>
-
-<style scoped lang="scss">
-    .code-editor-container {
-        transform: translateZ(0);
-        position: relative;
-        z-index: 40;
-    }
-</style>
-
-<style lang="scss">
-    .highlight-variable {
-        color: white !important;
-        border-radius: 5px;
-        background: purple;
-    }
-
-    .highlight-line {
-        background: transparentize(#1a73e8, 0.7);
-    }
-
-    .breakpoint-active {
-        background: red;
-        border: none !important;
-        border-radius: 50% !important;
-    }
-
-    .breakpoint {
-        transform: scale(0.8);
-        border: 1px solid gray;
-        border-radius: 15%;
-        margin-left: 5px;
-        cursor: pointer;
-    }
-
-    .target {
-        cursor: pointer;
-        transition: 0.2s background-color;
-        border-radius: 5px;
-    }
-
-    .target:hover {
-        background: orange;
-    }
-</style>

--- a/frontend/src/components/mainPage/codeEditor/CodeViewer.vue
+++ b/frontend/src/components/mainPage/codeEditor/CodeViewer.vue
@@ -1,0 +1,297 @@
+<template>
+    <div :id="id" class="code-editor-container">
+        <slot></slot>
+        <MonacoEditor
+            :id="id"
+            v-model:value="modelCode"
+            :options="options"
+            @editorDidMount="editorDidMount"
+        ></MonacoEditor>
+    </div>
+</template>
+
+<script>
+    import MonacoEditor from "monaco-editor-vue3";
+    import * as monaco from "monaco-editor/esm/vs/editor/editor.main";
+    import {
+        getVariablesArray,
+        monacoChangeToLegacyFormat,
+        moveBreakpoints,
+        moveTrackedVariables,
+    } from "@/javascript/utils/codeUtils";
+    import lineColumn from "line-column";
+    import { defineComponent } from "vue";
+    import { getCurrentThemeFromStorage } from "@/javascript/storage/themeStorage";
+    import { useProjectStore } from "@/stores/project";
+    import { mapActions, mapState } from "pinia";
+
+    export default defineComponent({
+        components: { MonacoEditor },
+        props: ["id", "code", "editable", "clickable", "showHighlightedVariables", "showBreakpoints"],
+
+        data() {
+            return {
+                options: {
+                    language: "cpp",
+                    theme: this.getEditorTheme(),
+                    automaticLayout: "true",
+                    readOnly: !this.$props.editable,
+                    minimap: { enabled: false },
+                    colorDecorators: true,
+                    glyphMargin: true,
+                },
+
+                currentVariablesDecorations: [],
+                currentBreakpointsDecorations: [],
+                currentLineDecorations: [],
+                currentTargetDecorations: [],
+            };
+        },
+
+        mounted() {
+            this.updateAllDecorations();
+            this.emitter.on("themeChangeEvent", () => {
+                this.options.theme = this.getEditorTheme();
+            });
+        },
+
+        methods: {
+            ...mapActions(useProjectStore, ["setCode", "toggleBreakpoint"]),
+
+            editorDidMount(editor) {
+                this.editor = editor;
+
+                editor.getModel().onDidChangeContent((event) => {
+                    this.handleChangeContent(event);
+                });
+
+                editor.onMouseDown((event) => {
+                    this.handleClick(event);
+                });
+            },
+
+            getEditorTheme() {
+                if (getCurrentThemeFromStorage() === "light") return "vs-light";
+                return "vs-dark";
+            },
+
+            handlePickVariable(event) {
+                const variable = this.getVariableInPosition(event.target.position);
+                this.$emit("pickVariableEvent", variable);
+            },
+
+            handleChangeContent(event) {
+                for (let change of event.changes) {
+                    // change.forceMoveMarkers is undefined when text is changed by code.
+                    // We must update decorations manually, because otherwise it doesn't show up on startup
+                    if (change.forceMoveMarkers === undefined) {
+                        this.updateAllDecorations();
+                        break;
+                    }
+                }
+
+                const legacyChanges = event.changes
+                    .filter((ch) => ch.forceMoveMarkers != undefined)
+                    .map((ch) => monacoChangeToLegacyFormat(this.$props.code, ch));
+
+                moveTrackedVariables(this.variables, legacyChanges, this.projectCode);
+                moveBreakpoints(this.breakpoints, legacyChanges);
+            },
+
+            handleClick(event) {
+                if (event.target.element.classList.contains("breakpoint")) {
+                    if (!this.$props.editable) return;
+                    this.toggleBreakpoint(event.target.position.lineNumber - 1);
+                    return;
+                }
+
+                if (event.target.element.classList.contains("target")) {
+                    this.handlePickVariable(event);
+                }
+            },
+
+            updateAllDecorations() {
+                this.updateVariablesDecorations(this.variablesDecorations);
+                this.updateBreakpointsDecorations(this.breakpointsDecorations);
+                this.updateLineDecorations(this.lineDecorations);
+                this.updateTargetDecorations(this.targetDecorations);
+            },
+
+            updateVariablesDecorations(dec) {
+                this.currentVariablesDecorations = this.editor.deltaDecorations(this.currentVariablesDecorations, dec);
+            },
+
+            updateBreakpointsDecorations(dec) {
+                this.currentBreakpointsDecorations = this.editor.deltaDecorations(
+                    this.currentBreakpointsDecorations,
+                    dec
+                );
+            },
+
+            updateLineDecorations(dec) {
+                this.currentLineDecorations = this.editor.deltaDecorations(this.currentLineDecorations, dec);
+            },
+
+            updateTargetDecorations(dec) {
+                this.currentTargetDecorations = this.editor.deltaDecorations(this.currentTargetDecorations, dec);
+            },
+        },
+
+        computed: {
+            ...mapState(useProjectStore, ["variables", "currentFrame", "breakpoints"]),
+            ...mapState(useProjectStore, { projectCode: (state) => state.code }),
+
+            modelCode: {
+                get() {
+                    return this.$props.code;
+                },
+                set(newValue) {
+                    this.setCode(newValue);
+                },
+            },
+
+            variablesDecorations() {
+                if (!this.$props.showHighlightedVariables) return [];
+
+                return this.variables.map((variable) => {
+                    let startLineColumn = lineColumn(this.$props.code, variable.start);
+                    let endLineColumn = lineColumn(this.$props.code, variable.end);
+                    return {
+                        range: new monaco.Range(
+                            startLineColumn.line,
+                            startLineColumn.col,
+                            endLineColumn.line,
+                            endLineColumn.col
+                        ),
+                        options: { inlineClassName: "highlight-variable" },
+                    };
+                });
+            },
+
+            breakpointsDecorations() {
+                if (!this.$props.showBreakpoints) return [];
+
+                return this.$props.code.split("\n").map((_, i) => {
+                    return {
+                        range: new monaco.Range(i + 1, 1, i + 1, 1),
+                        options: {
+                            glyphMarginClassName: this.getBreakpointClass(i),
+                        },
+                    };
+                });
+            },
+
+            lineDecorations() {
+                if (!this.$props.showHighlightedVariables) return [];
+                if (!this.isRunning) return [];
+
+                return [
+                    {
+                        range: new monaco.Range(this.currentFrame?.line + 1, 1, this.currentFrame?.line + 1, 1),
+                        options: { isWholeLine: true, className: "highlight-line" },
+                    },
+                ];
+            },
+
+            targetDecorations() {
+                if (!this.$props.clickable) return [];
+
+                return getVariablesArray(this.language, this.$props.code).map((word) => {
+                    return {
+                        range: new monaco.Range(
+                            word.startLineNumber,
+                            word.startColumn,
+                            word.endLineNumber,
+                            word.endColumn
+                        ),
+                        options: { inlineClassName: "target" },
+                    };
+                });
+            },
+
+            getBreakpointClass() {
+                return (i) => {
+                    if (this.breakpoints.hasId(i)) return "breakpoint breakpoint-active";
+                    if (!this.isRunning && this.$props.editable) return "breakpoint";
+                    return "";
+                };
+            },
+
+            getVariableInPosition() {
+                return (pos) => {
+                    const token = this.editor.getModel().getWordAtPosition(pos);
+                    const variable = {
+                        id: token.word,
+                        name: token.word,
+                        start: lineColumn(this.$props.code).toIndex(pos.lineNumber, token.startColumn),
+                        end: lineColumn(this.$props.code).toIndex(pos.lineNumber, token.endColumn),
+                    };
+                    return variable;
+                };
+            },
+        },
+
+        watch: {
+            editable: function (newVal) {
+                this.options.readOnly = !newVal;
+                this.editor.updateOptions({ readOnly: !newVal });
+            },
+
+            variablesDecorations: function (dec) {
+                this.updateVariablesDecorations(dec);
+            },
+
+            breakpointsDecorations: function (dec) {
+                this.updateBreakpointsDecorations(dec);
+            },
+
+            lineDecorations: function (dec) {
+                this.updateLineDecorations(dec);
+            },
+        },
+    });
+</script>
+
+<style scoped lang="scss">
+    .code-editor-container {
+        transform: translateZ(0);
+        position: relative;
+        z-index: 40;
+    }
+</style>
+
+<style lang="scss">
+    .highlight-variable {
+        color: white !important;
+        border-radius: 5px;
+        background: purple;
+    }
+
+    .highlight-line {
+        background: transparentize(#1a73e8, 0.7);
+    }
+
+    .breakpoint-active {
+        background: red;
+        border: none !important;
+        border-radius: 50% !important;
+    }
+
+    .breakpoint {
+        transform: scale(0.8);
+        border: 1px solid gray;
+        border-radius: 15%;
+        margin-left: 5px;
+        cursor: pointer;
+    }
+
+    .target {
+        cursor: pointer;
+        transition: 0.2s background-color;
+        border-radius: 5px;
+    }
+
+    .target:hover {
+        background: orange;
+    }
+</style>

--- a/frontend/src/components/modals/code/PickVariableModal.vue
+++ b/frontend/src/components/modals/code/PickVariableModal.vue
@@ -1,7 +1,7 @@
 <template>
     <AlgoModal title="Zaznacz zmienną">
-        <CodeEditor
-            id="pick-variable-editor"
+        <CodeViewer
+            id="pick-variable-viewer"
             :code="this.code"
             :editable="false"
             :clickable="true"
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-    import CodeEditor from "@/components/mainPage/codeEditor/CodeEditor.vue";
+    import CodeViewer from "../../mainPage/codeEditor/CodeViewer.vue";
     import AlgoModal from "@/components/global/AlgoModal.vue";
     import { defineComponent } from "vue";
     import { popModal } from "jenesius-vue-modal";
@@ -21,7 +21,7 @@
     import { useProjectStore } from "@/stores/project";
 
     export default defineComponent({
-        components: { CodeEditor, AlgoModal },
+        components: { CodeViewer, AlgoModal },
 
         props: ["callback"],
 
@@ -42,7 +42,7 @@
         width: 80vw;
     }
 
-    #pick-variable-editor {
+    #pick-variable-viewer {
         height: 20rem;
     }
 </style>

--- a/frontend/src/components/modals/code/ShowDebugCodeModal.vue
+++ b/frontend/src/components/modals/code/ShowDebugCodeModal.vue
@@ -1,6 +1,6 @@
 <template>
     <AlgoModal title="Kod debugujący">
-        <CodeEditor id="debug-code-editor" :code="this.debugCode" :editable="false" :clickable="false" />
+        <CodeViewer id="debug-code-editor" :code="this.debugCode" :editable="false" :clickable="false" />
 
         <template #buttons>
             <v-btn @click="copy()" color="primary">Kopiuj</v-btn>
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-    import CodeEditor from "@/components/mainPage/codeEditor/CodeEditor.vue";
+    import CodeViewer from "@/components/mainPage/codeEditor/CodeViewer.vue";
     import AlgoModal from "@/components/global/AlgoModal.vue";
     import { defineComponent } from "vue";
     import toast from "@/javascript/utils/toastUtils";
@@ -17,7 +17,7 @@
     import { useProjectStore } from "@/stores/project";
 
     export default defineComponent({
-        components: { AlgoModal, CodeEditor },
+        components: { AlgoModal, CodeViewer },
 
         methods: {
             copy() {

--- a/frontend/src/components/modals/code/ShowDebugCodeModal.vue
+++ b/frontend/src/components/modals/code/ShowDebugCodeModal.vue
@@ -1,6 +1,6 @@
 <template>
     <AlgoModal title="Kod debugujący">
-        <CodeViewer id="debug-code-editor" :code="this.debugCode" :editable="false" :clickable="false" />
+        <CodeViewer id="debug-code-viewer" :code="this.debugCode" :editable="false" :clickable="false" />
 
         <template #buttons>
             <v-btn @click="copy()" color="primary">Kopiuj</v-btn>
@@ -32,7 +32,7 @@
 </script>
 
 <style scoped>
-    #debug-code-editor {
+    #debug-code-viewer {
         height: 50vh;
         min-width: 90rem;
     }

--- a/frontend/src/components/modals/sceneObject/ConfigureSceneObjectModal.vue
+++ b/frontend/src/components/modals/sceneObject/ConfigureSceneObjectModal.vue
@@ -50,7 +50,7 @@
 
     export default defineComponent({
         components: { AlgoModal, AlgoTable },
-        props: ["sceneObject"],
+        props: ["sceneObject", "variable"],
 
         data() {
             return {
@@ -66,6 +66,10 @@
         mounted() {
             if (this.$props.sceneObject) {
                 this.model = cloneDeep(this.$props.sceneObject);
+            }
+
+            if (this.$props.variable) {
+                this.model.variable = this.$props.variable;
             }
         },
 


### PR DESCRIPTION
https://trello.com/c/bgwFi52T/84-doda%C4%87-opcj%C4%99-w-menu-kontekstowym-edytora-do-szybkiego-tworzenia-obiektu-scenicznego-%C5%9Bledz%C4%85cego-dan%C4%85-zmienn%C4%85

Dodałem dwa przyciski, odpowiednio ze skrótami CTRL+F10 i CTRL+F11:
- Nowy obiekt sceniczny - otwiera okno z nowym obiektem i wpisaną/zaznaczoną zmienną. 
- Śledź zmienną - nie otwiera okna, tylko od razu dodaje nowy obiekt sceniczny typu zmienna z zaznaczoną zmienną. Bardzo szybkie, do prostego śledzenia zmiennych omijamy całe okno z konfiguracją.

Przy próbie otwarcia modala ConfigureSceneObject w CodeEditor natrafiłem na problem z pętlą zależności (dependency loop), przez co zdecydowałem się na podział CodeViewer i CodeEditor. Być może przydałoby się trochę bardziej to porozdzielać (więcej rzeczy przenieść z Viewer do Editor), ale nie chciałem za dużo mieszać. Przykładowo funkcja handleClick() obsługuje kliknięcia w breakpointy (tylko potrzebne w Editorze) ale też w zmienne (już wymagane w Viewerze), a prosty mechanizm dziedziczenia w Vue nie pozwala na "dopisywanie" do funkcji. Musiałbym dodać jakąś tablicę metod wywoływanych w handleClick() (coś w rodzaju eventów, addEventListener, itd.). Na ten PR chyba wystarczy.