### PR TITLE
[Bug] Obliczanie poziomu zagłębienia zmiennej uwzględnia znaki ze stringów i charów

### DIFF
--- a/backend/src/project/structures/Variable.ts
+++ b/backend/src/project/structures/Variable.ts
@@ -1,7 +1,7 @@
 import { Static, Record, String, Number } from "runtypes";
 
 export const Variable = Record({
-    id: String,
+    id: String.withConstraint((s) => s.split("@").length == 2),
     start: Number,
     end: Number,
     name: String,

--- a/backend/src/project/structures/Variable.ts
+++ b/backend/src/project/structures/Variable.ts
@@ -1,7 +1,7 @@
 import { Static, Record, String, Number } from "runtypes";
 
 export const Variable = Record({
-    id: String.withConstraint((s) => s.split("@").length == 2),
+    id: String.withConstraint((s) => /^.*@[0-9]+$/.test(s)),
     start: Number,
     end: Number,
     name: String,

--- a/backend/tests/validation.test.ts
+++ b/backend/tests/validation.test.ts
@@ -56,14 +56,14 @@ let validNestedProject = {
         {
             id: 0,
             type: "graph" as ObjectType,
-            variable: { id: "", start: 0, end: 1, name: "" } as Variable,
+            variable: { id: "x@0", start: 0, end: 1, name: "x" } as Variable,
             converter: validConverter,
             color: "#000000",
             subobjects: [
                 {
                     id: 0,
                     type: "variable" as ObjectType,
-                    variable: { id: "", start: 0, end: 1, name: "" } as Variable,
+                    variable: { id: "y@2", start: 2, end: 3, name: "y" } as Variable,
                     converter: validConverter,
                     color: "#000000",
                     subobjects: [],

--- a/frontend/src/components/mainPage/codeEditor/CodeEditor.vue
+++ b/frontend/src/components/mainPage/codeEditor/CodeEditor.vue
@@ -78,11 +78,11 @@
             handlePickVariable(event) {
                 const word = this.editor.getModel().getWordAtPosition(event.target.position);
                 const variable = {
-                    id: event.target.element.innerText,
                     name: event.target.element.innerText,
                     start: lineColumn(this.$props.code).toIndex(event.target.position.lineNumber, word.startColumn),
                     end: lineColumn(this.$props.code).toIndex(event.target.position.lineNumber, word.endColumn),
                 };
+                variable.id = event.target.element.innerText + "@" + variable.start;
                 this.$emit("pickVariableEvent", variable);
             },
 

--- a/frontend/src/components/modals/menu/SaveProjectModal.vue
+++ b/frontend/src/components/modals/menu/SaveProjectModal.vue
@@ -14,7 +14,7 @@
     import { closeModal } from "jenesius-vue-modal";
     import { defineComponent } from "vue";
     import { useProjectStore } from "@/stores/project";
-    import { mapActions, mapState } from "pinia";
+    import { mapActions, mapWritableState } from "pinia";
 
     export default defineComponent({
         components: { AlgoModal },
@@ -29,7 +29,7 @@
         },
 
         computed: {
-            ...mapState(useProjectStore, ["title", "_id"]),
+            ...mapWritableState(useProjectStore, ["title", "_id"]),
         },
     });
 </script>

--- a/frontend/src/components/modals/menu/SaveProjectModal.vue
+++ b/frontend/src/components/modals/menu/SaveProjectModal.vue
@@ -1,6 +1,6 @@
 <template>
     <AlgoModal title="Zapisz projekt">
-        <v-text-field label="Tytuł projektu" v-model="tempTitle" clearable />
+        <v-text-field label="Tytuł projektu" v-model="newTitle" clearable />
 
         <template #buttons>
             <v-btn color="primary" @click="save(false)">Zapisz jako</v-btn>
@@ -21,20 +21,19 @@
 
         data() {
             return {
-                tempTitle: "",
+                newTitle: "",
             };
         },
 
         mounted() {
-            this.tempTitle = this.title;
+            this.newTitle = this.title;
         },
 
         methods: {
             ...mapActions(useProjectStore, ["saveProject"]),
 
             save(override) {
-                if (override) this.saveProject(this.title, true);
-                else this.saveProject(this.tempTitle, false);
+                this.saveProject(this.newTitle, override);
                 closeModal();
             },
         },

--- a/frontend/src/components/modals/menu/SaveProjectModal.vue
+++ b/frontend/src/components/modals/menu/SaveProjectModal.vue
@@ -1,6 +1,6 @@
 <template>
     <AlgoModal title="Zapisz projekt">
-        <v-text-field label="Tytuł projektu" v-model="title" clearable />
+        <v-text-field label="Tytuł projektu" v-model="tempTitle" clearable />
 
         <template #buttons>
             <v-btn color="primary" @click="save(false)">Zapisz jako</v-btn>
@@ -14,22 +14,33 @@
     import { closeModal } from "jenesius-vue-modal";
     import { defineComponent } from "vue";
     import { useProjectStore } from "@/stores/project";
-    import { mapActions, mapWritableState } from "pinia";
+    import { mapActions, mapState } from "pinia";
 
     export default defineComponent({
         components: { AlgoModal },
+
+        data() {
+            return {
+                tempTitle: "",
+            };
+        },
+
+        mounted() {
+            this.tempTitle = this.title;
+        },
 
         methods: {
             ...mapActions(useProjectStore, ["saveProject"]),
 
             save(override) {
-                this.saveProject(this.title, override);
+                if (override) this.saveProject(this.title, true);
+                else this.saveProject(this.tempTitle, false);
                 closeModal();
             },
         },
 
         computed: {
-            ...mapWritableState(useProjectStore, ["title", "_id"]),
+            ...mapState(useProjectStore, ["title", "_id"]),
         },
     });
 </script>

--- a/frontend/src/javascript/codeParser/CodeParser.js
+++ b/frontend/src/javascript/codeParser/CodeParser.js
@@ -1,3 +1,5 @@
+import { CodeParserUtils } from "./CodeParserUtils";
+
 export class CodeParser {
     actions = {
         "<algodebug-variable>": function (parent, tag) {
@@ -92,103 +94,16 @@ export class CodeParser {
     }
 
     prepareCode() {
-        this.code = CodeUtils.insertVariableTags(this.code, this.variables);
-        this.code = CodeUtils.insertBreakpointTags(this.code, this.breakpoints);
+        this.code = CodeParserUtils.insertVariableTags(this.code, this.variables);
+        this.code = CodeParserUtils.insertBreakpointTags(this.code, this.breakpoints);
     }
 
     parseCode() {
-        this.code = CodeUtils.removeVariableTags(this.code);
-        this.code = CodeUtils.replaceBreakpointTags(this.code, this.parsedBreakpoints);
-        this.code = CodeUtils.insertConvertersAfterIncludes(this.code, this.converters);
-        this.code = CodeUtils.insertConvertersAtTheEnd(this.code, this.converters);
-        this.code = CodeUtils.insertAlgodebugMacros(this.code);
-        this.code = CodeUtils.insertNecessaryIncludes(this.code);
-    }
-}
-
-class CodeUtils {
-    static insertVariableTags(code, variables) {
-        for (let variable of variables.sortedBy("start", -1)) {
-            code =
-                code.slice(0, variable.start) +
-                "<algodebug-variable>" +
-                variable.id +
-                "</algodebug-variable>" +
-                code.slice(variable.end);
-        }
-        return code;
-    }
-
-    static insertBreakpointTags(code, breakpoints) {
-        let lines = code.split("\n");
-        for (let breakpoint of breakpoints.sortedBy("id", -1)) {
-            lines[breakpoint.id] += `<algodebug-breakpoint>${breakpoint.id}</algodebug-breakpoint>`;
-        }
-        code = lines.join("\n");
-        return code;
-    }
-
-    static removeVariableTags(code) {
-        let i = -1;
-        while ((i = code.indexOf("<algodebug-variable>")) > 0) {
-            let start = i + "<algodebug-variable>".length;
-            let end = code.indexOf("</algodebug-variable>", start);
-            let variableID = code.substring(start, end);
-            let variableName = variableID.split("@")[0];
-            code = code.substring(0, i) + variableName + code.substring(end + "</algodebug-variable>".length);
-        }
-        return code;
-    }
-
-    static replaceBreakpointTags(code, parsedBreakpoints) {
-        for (let breakpoint of parsedBreakpoints) {
-            let variables = breakpoint.variables
-                .map((variable) => `ALGODEBUG_VARIABLE(${variable.name}, ${variable.id.split("@")[1]})`)
-                .join(" << ");
-            code = code.replace(
-                `<algodebug-breakpoint>${breakpoint.line}</algodebug-breakpoint>`,
-                variables.length !== 0
-                    ? ` ALGODEBUG_BREAKPOINT(${breakpoint.line}, ${variables});`
-                    : ` ALGODEBUG_EMPTY_BREAKPOINT(${breakpoint.line});`
-            );
-        }
-        return code;
-    }
-
-    static insertAlgodebugMacros(code) {
-        return (
-            `#define ALGODEBUG_VARIABLE(x, y) "<algodebug-variable " << "name=\\"" << #x << "@" << y << "\\">\\n" << x << "\\n</algodebug-variable>\\n"\n` +
-            `#define ALGODEBUG_BREAKPOINT(line, x) std::cout << "<algodebug-breakpoint " << "line=\\"" << line << "\\">\\n" << x << "</algodebug-breakpoint>\\n"\n` +
-            `#define ALGODEBUG_EMPTY_BREAKPOINT(line) std::cout << "<algodebug-breakpoint " << "line=\\"" << line << "\\">\\n</algodebug-breakpoint>\\n"\n\n` +
-            code
-        );
-    }
-
-    static insertConvertersAfterIncludes(code, converters) {
-        converters = converters
-            .map((converter) => converter.code.slice(0, converter.code.indexOf("{")).trim() + ";")
-            .join("\n");
-
-        let includeStartPosition = code.lastIndexOf("#include");
-        let includeEndPosition = code.indexOf(">", includeStartPosition);
-        let usingNamespaceStartPosition = code.lastIndexOf("using namespace");
-        let usingNamespaceEndPosition = code.indexOf(";", usingNamespaceStartPosition);
-
-        let position = Math.max(includeEndPosition, usingNamespaceEndPosition) + 1;
-        code = code.slice(0, position) + "\n\n" + converters + code.slice(position);
-        return code;
-    }
-
-    static insertConvertersAtTheEnd(code, converters) {
-        converters = converters.map((converter) => converter.code).join("\n\n");
-        return code + "\n\n" + converters;
-    }
-
-    static insertNecessaryIncludes(code) {
-        const regex = /#include[ \t]<iostream>/g;
-        if (!regex.test(code)) {
-            return "#include <iostream>\n" + code;
-        }
-        return code;
+        this.code = CodeParserUtils.removeVariableTags(this.code);
+        this.code = CodeParserUtils.replaceBreakpointTags(this.code, this.parsedBreakpoints);
+        this.code = CodeParserUtils.insertConvertersAfterIncludes(this.code, this.converters);
+        this.code = CodeParserUtils.insertConvertersAtTheEnd(this.code, this.converters);
+        this.code = CodeParserUtils.insertAlgodebugMacros(this.code);
+        this.code = CodeParserUtils.insertNecessaryIncludes(this.code);
     }
 }

--- a/frontend/src/javascript/codeParser/CodeParserUtils.js
+++ b/frontend/src/javascript/codeParser/CodeParserUtils.js
@@ -1,0 +1,97 @@
+const variableTagName = "algodebug-variable";
+const breakpointTagName = "algodebug-breakpoint";
+
+export class CodeParserUtils {
+    static insertVariableTags(code, variables) {
+        for (let variable of variables.sortedBy("start", -1)) {
+            code =
+                code.slice(0, variable.start) +
+                this.encloseInTag(variable.id, variableTagName) +
+                code.slice(variable.end);
+        }
+        return code;
+    }
+
+    static insertBreakpointTags(code, breakpoints) {
+        let lines = code.split("\n");
+        for (let breakpoint of breakpoints.sortedBy("id", -1)) {
+            lines[breakpoint.id] += this.encloseInTag(breakpoint.id, breakpointTagName);
+        }
+        code = lines.join("\n");
+        return code;
+    }
+
+    static removeVariableTags(code) {
+        code = this.removeTagsAndMapContent(code, variableTagName, (content) => {
+            return content.split("@")[0];
+        });
+        return code;
+    }
+
+    static replaceBreakpointTags(code, parsedBreakpoints) {
+        for (let breakpoint of parsedBreakpoints) {
+            let variables = breakpoint.variables
+                .map((variable) => `ALGODEBUG_VARIABLE(${variable.name}, ${variable.id.split("@")[1]})`)
+                .join(" << ");
+            code = code.replace(
+                this.encloseInTag(breakpoint.line, breakpointTagName),
+                variables.length !== 0
+                    ? ` ALGODEBUG_BREAKPOINT(${breakpoint.line}, ${variables});`
+                    : ` ALGODEBUG_EMPTY_BREAKPOINT(${breakpoint.line});`
+            );
+        }
+        return code;
+    }
+
+    static insertAlgodebugMacros(code) {
+        return (
+            `#define ALGODEBUG_VARIABLE(x, y) "<algodebug-variable " << "name=\\"" << #x << "@" << y << "\\">\\n" << x << "\\n</algodebug-variable>\\n"\n` +
+            `#define ALGODEBUG_BREAKPOINT(line, x) std::cout << "<algodebug-breakpoint " << "line=\\"" << line << "\\">\\n" << x << "</algodebug-breakpoint>\\n"\n` +
+            `#define ALGODEBUG_EMPTY_BREAKPOINT(line) std::cout << "<algodebug-breakpoint " << "line=\\"" << line << "\\">\\n</algodebug-breakpoint>\\n"\n\n` +
+            code
+        );
+    }
+
+    static insertConvertersAfterIncludes(code, converters) {
+        converters = converters
+            .map((converter) => converter.code.slice(0, converter.code.indexOf("{")).trim() + ";")
+            .join("\n");
+
+        let includeStartPosition = code.lastIndexOf("#include");
+        let includeEndPosition = code.indexOf(">", includeStartPosition);
+        let usingNamespaceStartPosition = code.lastIndexOf("using namespace");
+        let usingNamespaceEndPosition = code.indexOf(";", usingNamespaceStartPosition);
+
+        let position = Math.max(includeEndPosition, usingNamespaceEndPosition) + 1;
+        code = code.slice(0, position) + "\n\n" + converters + code.slice(position);
+        return code;
+    }
+
+    static insertConvertersAtTheEnd(code, converters) {
+        converters = converters.map((converter) => converter.code).join("\n\n");
+        return code + "\n\n" + converters;
+    }
+
+    static insertNecessaryIncludes(code) {
+        const regex = /#include[ \t]*<iostream>/g;
+        if (!regex.test(code)) {
+            return "#include <iostream>\n" + code;
+        }
+        return code;
+    }
+
+    static removeTagsAndMapContent(code, tag, mappingFunction) {
+        let i = 0;
+        while ((i = code.indexOf(`<${tag}>`)) > 0) {
+            let start = i + `<${tag}>`.length;
+            let end = code.indexOf(`</${tag}>`, start);
+            let content = code.substring(start, end);
+            code = code.substring(0, i) + mappingFunction(content) + code.substring(end + `</${tag}>`.length);
+        }
+        return code;
+    }
+
+    static encloseInTag(content, tag) {
+        return `<${tag}>${content}</${tag}>`;
+    }
+}

--- a/frontend/src/javascript/prototypes/String.js
+++ b/frontend/src/javascript/prototypes/String.js
@@ -28,3 +28,13 @@ String.prototype.escapeHTML = function () {
 String.prototype.numberOfLines = function () {
     return this.split("\n").length;
 };
+
+String.prototype.findAllOccurences = function (needle) {
+    let result = [];
+    let i = 0;
+    while ((i = this.indexOf(needle, i)) >= 0) {
+        result.push(i);
+        i += needle.length;
+    }
+    return result;
+};

--- a/frontend/src/javascript/stage/Painter.js
+++ b/frontend/src/javascript/stage/Painter.js
@@ -47,9 +47,9 @@ export class Painter {
     }
 
     getVariable(sceneObject) {
-        const name = sceneObject.variable.name;
+        const id = sceneObject.variable.id;
         const type = sceneObject.type;
-        let variable = this.frame.variables[name];
+        let variable = this.frame.variables[id];
         return variable ? parse(variable, type) : undefined;
     }
 

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -126,7 +126,8 @@ export const useProjectStore = defineStore("project", {
         /* Variables */
         updateVariable(payload) {
             const { id, variable } = payload;
-            variable.id = variable.name = this.code.substring(variable.start, variable.end);
+            variable.name = this.code.substring(variable.start, variable.end);
+            variable.id = variable.name + "@" + variable.start;
             this.sceneObjects
                 .flatMap((sceneObject) => [sceneObject, ...sceneObject.subobjects])
                 .find((sceneObject) => sceneObject.variable?.id === id).variable = variable;

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -153,7 +153,7 @@ export const useProjectStore = defineStore("project", {
             this.title = title;
             sendRequest("/project/save", this.jsonForSave(override, title), override ? "PUT" : "POST").then(
                 (responseData) => {
-                    this._id = responseData.insertedId;
+                    if (!override) this._id = responseData.insertedId;
                 }
             );
         },

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -150,10 +150,10 @@ export const useProjectStore = defineStore("project", {
         },
 
         saveProject(title, override) {
-            this.title = title;
+            if (override || this.title == "") this.title = title;
             sendRequest("/project/save", this.jsonForSave(override, title), override ? "PUT" : "POST").then(
                 (responseData) => {
-                    if (!override) this._id = responseData.insertedId;
+                    if (this._id == null) this._id = responseData.insertedId;
                 }
             );
         },

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -149,10 +149,10 @@ export const useProjectStore = defineStore("project", {
         },
 
         saveProject(title, override) {
+            this.title = title;
             sendRequest("/project/save", this.jsonForSave(override, title), override ? "PUT" : "POST").then(
                 (responseData) => {
-                    this.id = responseData.id;
-                    this.title = responseData.title;
+                    this._id = responseData.insertedId;
                 }
             );
         },


### PR DESCRIPTION
https://trello.com/c/EzVYRHOQ/98-bug-obliczanie-poziomu-zag%C5%82%C4%99bienia-zmiennej-uwzgl%C4%99dnia-znaki-ze-string%C3%B3w-i-char%C3%B3w

[Zmergowałem zawczasu z poprzednim PR, bo byłoby sporo konfliktów. Jak poprzedni przejdzie, możesz przejrzeć ten, jak nie, to skupmy się na razie tylko na tamtym]

Przebudowałem trochę stary system wyszukiwania tagów, wydawał mi się dość skomplikowany (choć wydajny, co na plus).
Obecnie tworzę dużą tablicę ze wszystkimi tokenami i ich pozycjami, poprzez złączenie i posortowanie mniejszych tablic, które zawierają wszystkie wystąpienia konkretnego tokenu. 
Dodatkowo, obliczam przedziały w kodzie, w których nie należy tokenów rozważać, tj.:
- komentarze jednoliniowe
- komentarze wieloliniowe
- stringi ("ab}c")
- chary ('}')

Uwzględniłem także znaki ucieczki, żeby np.: `string xxx = "aaa\"bbb"` był traktowany jako jeden string, a nie "półtora".
![obraz](https://user-images.githubusercontent.com/27860636/221443710-ba770504-11a3-4a8e-b407-63de85b7a2fc.png)

