### PR TITLE
[Bug] Naprawa jasnego tła modala w trybie produkcyjnym.

### DIFF
--- a/frontend/src/scss/global.scss
+++ b/frontend/src/scss/global.scss
@@ -98,6 +98,6 @@ h5 {
 }
 
 .modal-container {
-    background-color: transparentize(black, 0.7);
+    background-color: transparentize(black, 0.7) !important;
     z-index: 2000;
 }


### PR DESCRIPTION
Podczas używania AlgoDebuga w trybie produkcyjnym Modal ma tło koloru jasnego.
W wersji deweloperskiej ten błąd nie występuje.
Zostało naprawione to dodaniem keyworda !important w pliku global.scss.
https://trello.com/c/hNYY6jU5/101-bug-naprawa-jasnego-t%C5%82a-dla-modala-w-trybie-produkcyjnym