### PR TITLE
Workflow umożliwiający wdrażanie frontendu.

### DIFF
--- a/.github/workflows/cd_frontend.yml
+++ b/.github/workflows/cd_frontend.yml
@@ -1,13 +1,15 @@
 name: Frontend CD
 
 on:
-  push:
-    branches: ["master", "feat/add_cd"]
+  workflow_run:
+    workflows: ["Frontend CI"]
+    branches: [main, feat/add_cd]
+    types:
+      - completed
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    needs: ci_frontend
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cd_frontend.yml
+++ b/.github/workflows/cd_frontend.yml
@@ -2,7 +2,7 @@ name: Frontend CD
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master", "feat/add_cd"]
 
 jobs:
   deploy:

--- a/.github/workflows/cd_frontend.yml
+++ b/.github/workflows/cd_frontend.yml
@@ -1,0 +1,28 @@
+name: Frontend CD
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    needs: ci_frontend
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: "Install dependencies"
+        run: npm ci
+        working-directory: "./frontend"
+      - name: "Build"
+        run: npm run build
+        working-directory: "./frontend"
+      - name: "Deploy built project on VPS"
+        uses: wangyucode/sftp-upload-action@main
+        with:
+          host: "${{ secrets.SFTP_ADDRESS }}"
+          port: "${{ secrets.SFTP_PORT }}"
+          username: "${{ secrets.SFTP_USERNAME }}"
+          password: "${{ secrets.SFTP_PASSWORD }}"
+          localDir: "./frontend/dist"
+          remoteDir: "/home/${{ secrets.SFTP_USERNAME }}/www/"
+          dryRun: false

--- a/.github/workflows/cd_frontend.yml
+++ b/.github/workflows/cd_frontend.yml
@@ -1,5 +1,9 @@
 name: Frontend CD
 
+on:
+  push:
+    branches: ["main"]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -9,7 +9,7 @@ on:
       - frontend/**
 
 jobs:
-  build:
+  ci_frontend:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -1,16 +1,10 @@
-name: Frontend CD
+name: Deploy Frontend
 
-on:
-  workflow_run:
-    workflows: ["Frontend CI"]
-    branches: [main, feat/add_cd]
-    types:
-      - completed
+on: [workflow_dispatch]
 
 jobs:
-  deploy:
+  deploy_frontend:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -1,6 +1,6 @@
 name: Deploy Frontend
 
-on: [workflow_dispatch]
+on: [ workflow_dispatch ]
 
 jobs:
   deploy_frontend:
@@ -16,6 +16,9 @@ jobs:
       - name: "Build"
         run: npm run build
         working-directory: "./frontend"
+      - name: "Pack the project into an archive"
+        run: mkdir packedDist && tar -cf ./packedDist/frontend.tar -C ./dist .
+        working-directory: "./frontend"
       - name: "Deploy built project on VPS"
         uses: wangyucode/sftp-upload-action@main
         with:
@@ -23,6 +26,14 @@ jobs:
           port: "${{ secrets.SFTP_PORT }}"
           username: "${{ secrets.SFTP_USERNAME }}"
           password: "${{ secrets.SFTP_PASSWORD }}"
-          localDir: "./frontend/dist"
-          remoteDir: "/home/${{ secrets.SFTP_USERNAME }}/www/"
+          localDir: "./frontend/packedDist"
+          remoteDir: "/home/${{ secrets.SFTP_USERNAME }}/gh/"
           dryRun: false
+      - name: "Run deploy script on server"
+        uses: garygrossgarten/github-action-ssh@release
+        with:
+          command: "bash deploy_www.sh"
+          host: "${{ secrets.SFTP_ADDRESS }}"
+          port: "${{ secrets.SFTP_PORT }}"
+          username: "${{ secrets.SFTP_USERNAME }}"
+          password: "${{ secrets.SFTP_PASSWORD }}"


### PR DESCRIPTION
Dodałem workflow wdrażający frontend na mikrusa, który uruchamia się tylko wtedy, gdy chce tego właściciel repozytorium. Uważam, że to najlepsze rozwiązanie, ponieważ często zdarzało mi się, że dwa workflowy wdrażały jednocześnie i powodowały błędy.

Przed uruchomieniem workflowu należy go skonfigurować w zakładce Settings -> Secret and variables -> Actions, gdzie można ustawić zmienne SFTP_ADDRESS, SFTP_PASSWORD, SFTP_PORT oraz SFTP_USERNAME.

Jednakże należy pamiętać, że najlepiej korzystać tylko z tego workflowu do deployowania, ponieważ używa on specjalnego konta 'cd'. Jeśli zdeployujemy z roota, 'cd' nie będzie mógł usunąć plików z /var/www/html. W takim przypadku Github poinformuje nas o tym błędzie. Uważam jednak, że to nie jest duży problem, a w razie potrzeby będę mógł to naprawić.

Aby uruchomić ten workflow, należy przejść do repozytorium na Githubie i przejść do zakładki "Actions". Tam należy wybrać nasz workflow "Deploy Frontent" i kliknąć przycisk "Run Workflow". Następnie należy wybrać branch, na którym ma zostać uruchomiony workflow.

Hasło wyśle na Discordzie.