### PR TITLE
Nowy pracownik miesiąca luty 2023

### DIFF
--- a/frontend/src/components/modals/other/DevelopersModal.vue
+++ b/frontend/src/components/modals/other/DevelopersModal.vue
@@ -45,7 +45,7 @@
                 },
                 {
                     name: "Łukasz Skabowski",
-                    role: "Pracownik miesiąca grudzień 2022",
+                    role: "Pracownik miesiąca grudzień 2022, luty 2023",
                     githubId: 27860636,
                     githubLink: "https://github.com/xenix1337",
                 },


### PR DESCRIPTION
Dodanie informacji o nowym pracowniku miesiąca w firmie Algodebug spólka z ograniczoną odpowiedzialnością.
Oraz jest to zarazem zgłoszenie na konkurs "najmniejszy PR w Algodebugu w Q1 2023".