### PR TITLE
[Konwertery] Możliwość dodawania kilku zmiennych do jednego obiektu/właściwości.

### DIFF
--- a/backend/src/project/structures/SceneObject.ts
+++ b/backend/src/project/structures/SceneObject.ts
@@ -1,6 +1,6 @@
 import { Converter } from "../../converter/model";
 import { sanitizeConverter } from "../../converter/service";
-import { Variable, sanitizeVariable } from "./Variable";
+import { Variable, sanitizeVariables } from "./Variable";
 import { ObjectType } from "./ObjectType";
 import { Record, String, Array, Number, Lazy, Runtype, Unknown, Optional, Null } from "runtypes";
 
@@ -9,7 +9,7 @@ export const SceneObject: Runtype<SceneObject> = Lazy(() =>
     Record({
         id: Number,
         type: ObjectType,
-        variable: Variable,
+        variables: Array(Variable),
         converter: Converter.Or(Null),
         color: Optional(String.Or(Null)),
         position: Optional(Unknown.Or(Null)),
@@ -21,7 +21,7 @@ export const SceneObject: Runtype<SceneObject> = Lazy(() =>
 export type SceneObject = {
     id: number;
     type: ObjectType;
-    variable: Variable;
+    variables: Variable[];
     converter: Converter | null;
     color?: string | null;
     position?: unknown | null;
@@ -32,7 +32,7 @@ export const sanitizeSceneObject = (s: SceneObject): SceneObject => {
     const result = {
         id: s.id,
         type: s.type,
-        variable: sanitizeVariable(s.variable),
+        variables: sanitizeVariables(s.variables),
         converter: sanitizeConverter(s.converter),
     } as SceneObject;
 

--- a/backend/src/project/structures/Variable.ts
+++ b/backend/src/project/structures/Variable.ts
@@ -9,11 +9,8 @@ export const Variable = Record({
 
 export type Variable = Static<typeof Variable>;
 
-export const sanitizeVariable = (m: Variable) => {
-    return {
-        id: m.id,
-        start: m.start,
-        end: m.end,
-        name: m.name,
-    } as Variable;
+export const sanitizeVariables = (m: Variable[]) => {
+    return m.map((v) => {
+        return { id: v.id, start: v.start, end: v.end, name: v.name };
+    }) as Variable[];
 };

--- a/backend/tests/validation.test.ts
+++ b/backend/tests/validation.test.ts
@@ -56,14 +56,14 @@ let validNestedProject = {
         {
             id: 0,
             type: "graph" as ObjectType,
-            variable: { id: "x@0", start: 0, end: 1, name: "x" } as Variable,
+            variables: [{ id: "x@0", start: 0, end: 1, name: "x" }] as Variable[],
             converter: validConverter,
             color: "#000000",
             subobjects: [
                 {
                     id: 0,
                     type: "variable" as ObjectType,
-                    variable: { id: "y@2", start: 2, end: 3, name: "y" } as Variable,
+                    variables: [{ id: "y@2", start: 2, end: 3, name: "y" }] as Variable[],
                     converter: validConverter,
                     color: "#000000",
                     subobjects: [],

--- a/frontend/src/components/global/AlgoModal.vue
+++ b/frontend/src/components/global/AlgoModal.vue
@@ -52,9 +52,6 @@
         border-width: 1px;
         border-color: $border-color-root;
 
-        display: flex;
-        flex-direction: column;
-
         &__content {
             padding: 1rem 2rem;
             max-height: 65vh;

--- a/frontend/src/components/global/AlgoModal.vue
+++ b/frontend/src/components/global/AlgoModal.vue
@@ -52,6 +52,9 @@
         border-width: 1px;
         border-color: $border-color-root;
 
+        display: flex;
+        flex-direction: column;
+
         &__content {
             padding: 1rem 2rem;
             max-height: 65vh;

--- a/frontend/src/components/global/AlgoTable.vue
+++ b/frontend/src/components/global/AlgoTable.vue
@@ -44,6 +44,7 @@
     import { getSceneObjectTypeLabel } from "@/javascript/utils/sceneObjectTypesUtils";
     import { pushModal } from "jenesius-vue-modal";
     import { defineComponent } from "vue";
+    import { cloneDeep } from "lodash";
 
     export default defineComponent({
         components: { AlgoLink },
@@ -61,7 +62,7 @@
 
         methods: {
             addRow() {
-                this.model.addElement({ ...this.emptyRow });
+                this.model.addElement(cloneDeep(this.emptyRow));
             },
 
             removeRow(id) {
@@ -80,8 +81,11 @@
             selectVariable(row) {
                 pushModal(PickVariableModal, {
                     callback: (selectedVariable) => {
-                        row.variable = selectedVariable;
+                        let index = row.variables.findIndex((variable) => variable.id === selectedVariable.id);
+                        if (index == -1) row.variables.push(selectedVariable);
+                        else row.variables.splice(index, 1);
                     },
+                    sceneObject: row,
                 });
             },
 
@@ -103,7 +107,7 @@
 
             variableName() {
                 return (row) => {
-                    return row.variable?.name;
+                    return row.variables.map((v) => v.name).join(", ");
                 };
             },
 

--- a/frontend/src/components/mainPage/MainPage.vue
+++ b/frontend/src/components/mainPage/MainPage.vue
@@ -9,7 +9,8 @@
                     :code="this.code"
                     :editable="!this.isRunning && !this.waitingForCompile"
                     :clickable="false"
-                    :showHighlightedVariables="true"
+                    :highlightedVariables="this.variables"
+                    :showCurrentLine="true"
                     :showBreakpoints="true"
                 >
                     <CodePanel />
@@ -47,7 +48,7 @@
         },
 
         computed: {
-            ...mapState(useProjectStore, ["code", "isRunning", "waitingForCompile"]),
+            ...mapState(useProjectStore, ["code", "isRunning", "waitingForCompile", "variables"]),
             projectId() {
                 const urlParams = new URLSearchParams(window.location.search);
                 return urlParams.get("projectId");

--- a/frontend/src/components/mainPage/codeEditor/CodeEditor.vue
+++ b/frontend/src/components/mainPage/codeEditor/CodeEditor.vue
@@ -23,7 +23,7 @@
                     const variable = this.getVariableInPosition(this.editor.getPosition());
                     const sceneObject = {
                         type: "variable",
-                        variable: variable,
+                        variables: [variable],
                         converter: null,
                         subobjects: [],
                     };
@@ -44,7 +44,7 @@
                     const variable = this.getVariableInPosition(this.editor.getPosition());
 
                     pushModal(ConfigureSceneObjectModal, {
-                        variable: variable,
+                        variables: [variable],
                     });
                 },
             });

--- a/frontend/src/components/mainPage/codeEditor/CodeViewer.vue
+++ b/frontend/src/components/mainPage/codeEditor/CodeViewer.vue
@@ -27,7 +27,7 @@
 
     export default defineComponent({
         components: { MonacoEditor },
-        props: ["id", "code", "editable", "clickable", "showHighlightedVariables", "showBreakpoints"],
+        props: ["id", "code", "editable", "clickable", "highlightedVariables", "showBreakpoints", "showCurrentLine"],
 
         data() {
             return {
@@ -151,9 +151,9 @@
             },
 
             variablesDecorations() {
-                if (!this.$props.showHighlightedVariables) return [];
+                if (this.highlightedVariables == null) return [];
 
-                return this.variables.map((variable) => {
+                return this.highlightedVariables.map((variable) => {
                     let startLineColumn = lineColumn(this.$props.code, variable.start);
                     let endLineColumn = lineColumn(this.$props.code, variable.end);
                     return {
@@ -182,7 +182,7 @@
             },
 
             lineDecorations() {
-                if (!this.$props.showHighlightedVariables) return [];
+                if (!this.$props.showCurrentLine) return [];
                 if (!this.isRunning) return [];
 
                 return [

--- a/frontend/src/components/mainPage/codeEditor/CodeViewer.vue
+++ b/frontend/src/components/mainPage/codeEditor/CodeViewer.vue
@@ -1,12 +1,7 @@
 <template>
     <div :id="id" class="code-editor-container">
         <slot></slot>
-        <MonacoEditor
-            :id="id"
-            v-model:value="modelCode"
-            :options="options"
-            @editorDidMount="editorDidMount"
-        ></MonacoEditor>
+        <MonacoEditor v-model:value="modelCode" :options="options" @editorDidMount="editorDidMount"></MonacoEditor>
     </div>
 </template>
 

--- a/frontend/src/components/mainPage/scene/subcomponents/SceneObjectsPanel.vue
+++ b/frontend/src/components/mainPage/scene/subcomponents/SceneObjectsPanel.vue
@@ -37,7 +37,7 @@
             sceneObjectLabel() {
                 return (sceneObject) => {
                     return `${getSceneObjectTypeLabel(sceneObject.type)} ${
-                        sceneObject.variable ? sceneObject.variable.name : "null"
+                        sceneObject.variables.length > 0 ? sceneObject.variables[0].name : "null"
                     }`;
                 };
             },

--- a/frontend/src/components/modals/code/PickVariableModal.vue
+++ b/frontend/src/components/modals/code/PickVariableModal.vue
@@ -1,12 +1,12 @@
 <template>
-    <AlgoModal title="Zaznacz zmienną">
+    <AlgoModal title="Zaznacz zmienne" closeButtonLabel="Gotowe">
         <CodeViewer
             id="pick-variable-viewer"
             :code="this.code"
             :editable="false"
             :clickable="true"
             @pickVariableEvent="handlePickVariable"
-            :showHighlightedVariables="true"
+            :highlightedVariables="this.$props.sceneObject.variables"
             :showBreakpoints="true"
         />
     </AlgoModal>
@@ -23,12 +23,26 @@
     export default defineComponent({
         components: { CodeViewer, AlgoModal },
 
-        props: ["callback"],
+        props: ["callback", "sceneObject"],
+
+        data() {
+            return {
+                selectedVariables: [],
+            };
+        },
+
+        mounted() {
+            this.selectedVariables = this.$props.sceneObject.variables;
+        },
 
         methods: {
             handlePickVariable(variable) {
                 this.$props.callback(variable);
-                popModal();
+                /*
+                let index = this.selectedVariables.findIndex((v) => v.id === variable.id);
+                if (index == -1) this.selectedVariables.push(variable);
+                else this.selectedVariables.splice(index, 1);
+                */
             },
         },
         computed: {

--- a/frontend/src/components/modals/code/PickVariableModal.vue
+++ b/frontend/src/components/modals/code/PickVariableModal.vue
@@ -37,11 +37,6 @@
         methods: {
             handlePickVariable(variable) {
                 this.$props.callback(variable);
-                /*
-                let index = this.selectedVariables.findIndex((v) => v.id === variable.id);
-                if (index == -1) this.selectedVariables.push(variable);
-                else this.selectedVariables.splice(index, 1);
-                */
             },
         },
         computed: {

--- a/frontend/src/components/modals/code/PickVariableModal.vue
+++ b/frontend/src/components/modals/code/PickVariableModal.vue
@@ -16,7 +16,6 @@
     import CodeViewer from "../../mainPage/codeEditor/CodeViewer.vue";
     import AlgoModal from "@/components/global/AlgoModal.vue";
     import { defineComponent } from "vue";
-    import { popModal } from "jenesius-vue-modal";
     import { mapState } from "pinia";
     import { useProjectStore } from "@/stores/project";
 

--- a/frontend/src/components/modals/code/PickVariableModal.vue
+++ b/frontend/src/components/modals/code/PickVariableModal.vue
@@ -1,5 +1,16 @@
 <template>
     <AlgoModal title="Zaznacz zmienne" closeButtonLabel="Gotowe">
+        <div id="variable-chips-container">
+            <v-chip
+                closable
+                v-for="variable in this.selectedVariables"
+                class="ma-2"
+                :key="variable.id"
+                @click:close="deleteVariable(variable)"
+            >
+                {{ variable.name }}
+            </v-chip>
+        </div>
         <CodeViewer
             id="pick-variable-viewer"
             :code="this.code"
@@ -38,6 +49,10 @@
             handlePickVariable(variable) {
                 this.$props.callback(variable);
             },
+
+            deleteVariable(variable) {
+                this.$props.callback(variable);
+            },
         },
         computed: {
             ...mapState(useProjectStore, ["code"]),
@@ -48,9 +63,18 @@
 <style scoped>
     .dialog {
         width: 80vw;
+        height: 85vh;
+        display: flex;
+        flex-direction: column;
+    }
+
+    #variable-chips-container {
+        height: 15%;
+        white-space: nowrap;
+        overflow-y: auto;
     }
 
     #pick-variable-viewer {
-        height: 20rem;
+        height: 85%;
     }
 </style>

--- a/frontend/src/components/modals/sceneObject/ConfigureSceneObjectModal.vue
+++ b/frontend/src/components/modals/sceneObject/ConfigureSceneObjectModal.vue
@@ -10,7 +10,7 @@
         </v-combobox>
 
         <span @click="selectVariable">
-            <v-combobox label="Przypisana zmienna" :model-value="variableName" @keypress.prevent />
+            <v-combobox label="Przypisane zmienne" :model-value="variableName" @keypress.prevent />
         </span>
 
         <span @click="selectConverter">
@@ -21,8 +21,8 @@
             v-if="hasSubtypes(model.type)"
             :sceneObject="model"
             label="Właściwości"
-            :headers="['Rodzaj', 'Przypisana zmienna', 'Konwerter', 'Kolor']"
-            :emptyRow="{ type: null, variable: null, converter: null, color: '#000000' }"
+            :headers="['Rodzaj', 'Przypisane zmienne', 'Konwerter', 'Kolor']"
+            :emptyRow="{ type: null, variables: [], converter: null, color: '#000000' }"
         ></AlgoTable>
 
         <template #buttons>
@@ -57,7 +57,7 @@
             return {
                 model: {
                     type: null,
-                    variable: null,
+                    variables: [],
                     converter: null,
                     subobjects: [],
                 },
@@ -72,7 +72,7 @@
             }
 
             if (this.$props.variable) {
-                this.model.variable = this.$props.variable;
+                this.model.variables = [this.$props.variable];
             }
 
             this.modelBeforeChanges = JSON.stringify(this.model);
@@ -97,8 +97,11 @@
             selectVariable() {
                 pushModal(PickVariableModal, {
                     callback: (selectedVariable) => {
-                        this.model.variable = selectedVariable;
+                        let index = this.model.variables.findIndex((variable) => variable.id === selectedVariable.id);
+                        if (index == -1) this.model.variables.push(selectedVariable);
+                        else this.model.variables.splice(index, 1);
                     },
+                    sceneObject: this.model,
                 });
             },
 
@@ -125,7 +128,7 @@
             },
 
             variableName() {
-                return this.model.variable?.name;
+                return this.model.variables.map((v) => v.name).join(", ");
             },
 
             converterTitle() {

--- a/frontend/src/javascript/stage/Painter.js
+++ b/frontend/src/javascript/stage/Painter.js
@@ -47,7 +47,7 @@ export class Painter {
     }
 
     getVariable(sceneObject) {
-        const id = sceneObject.variable.id;
+        const id = sceneObject.variables[0].id;
         const type = sceneObject.type;
         let variable = this.frame.variables[id];
         return variable ? parse(variable, type) : undefined;

--- a/frontend/src/javascript/stage/painters/VariablePainter.js
+++ b/frontend/src/javascript/stage/painters/VariablePainter.js
@@ -13,11 +13,15 @@ export class VariablePainter extends Painter {
 
         const variableText = new Konva.Text({
             name: "variable",
-            text: this.sceneObject.variable.name + ": " + variable,
+            text: this.getLabel() + ": " + variable,
             fontSize: this.style.fontSize,
             fill: this.color,
             y: variableNumber * this.style.fontSize,
         });
         this.mainGroup.add(variableText);
+    }
+
+    getLabel() {
+        return this.sceneObject.variables.map((variable) => variable.name).join(", ");
     }
 }

--- a/frontend/src/javascript/utils/validationUtils.js
+++ b/frontend/src/javascript/utils/validationUtils.js
@@ -2,11 +2,12 @@ import toast from "@/javascript/utils/toastUtils";
 
 export function validateSceneObject(model) {
     if (!assert(model.type != null, "Podaj rodzaj obiektu")) return false;
-    if (!assert(model.variable != null, "Przypisz zmienną")) return false;
+    if (!assert(model.variables.length != 0, "Przypisz zmienną")) return false;
     let problemWithSubobject = false;
     model.subobjects.forEach((subObj) => {
         if (!assert(subObj.type != null, "Podaj rodzaj właściwości")) return (problemWithSubobject = true);
-        if (!assert(subObj.variable != null, "Przypisz zmienną do właściwości")) return (problemWithSubobject = true);
+        if (!assert(subObj.variables.length != 0, "Przypisz zmienną do właściwości"))
+            return (problemWithSubobject = true);
     });
     if (problemWithSubobject) return false;
     return true;

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -24,8 +24,9 @@ export const useProjectStore = defineStore("project", {
 
         variables() {
             return this.sceneObjectsFlat
-                .filter((sceneObject) => sceneObject.variable != null)
-                .map((sceneObject) => sceneObject.variable)
+                .filter((sceneObject) => sceneObject.variables != null)
+                .map((sceneObject) => sceneObject.variables)
+                .flat()
                 .unique();
         },
 
@@ -138,12 +139,20 @@ export const useProjectStore = defineStore("project", {
             variable.id = variable.name + "@" + variable.start;
             this.sceneObjects
                 .flatMap((sceneObject) => [sceneObject, ...sceneObject.subobjects])
-                .find((sceneObject) => sceneObject.variable?.id === id).variable = variable;
+                .forEach((sceneObject) => {
+                    sceneObject.variables.forEach((oldVariable, index) => {
+                        if (oldVariable.id === id) sceneObject.variables[index] = variable;
+                    });
+                });
         },
         deleteVariable(id) {
             this.sceneObjects
                 .flatMap((sceneObject) => [sceneObject, ...sceneObject.subobjects])
-                .find((sceneObject) => sceneObject.variable?.id === id).variable = null;
+                .forEach((sceneObject) => {
+                    sceneObject.variables = sceneObject.variables.filter((oldVariable) => {
+                        oldVariable.id !== id;
+                    });
+                });
         },
 
         /* Logic */


### PR DESCRIPTION
https://trello.com/c/xJJKQrKb/103-konwertery-mo%C5%BCliwo%C5%9B%C4%87-dodawania-kilku-zmiennych-do-jednego-obiektu-w%C5%82a%C5%9Bciwo%C5%9Bci

Obecnie nie modyfikowałem zbytnio kodu generującego kod debugujący. Do każdego obiektu/właściwości można przypisać dowolnie wiele zmiennych, choć na ten moment brana pod uwagę będzie tylko pierwsza od lewej. Przy zmianie działania konwerterów (zamiana na funkcje) dodam łączenie tego.

Trochę zmienił się również wygląd zaznaczania zmiennych, teraz okno samo się nie zamyka, a podświetlają się tylko zmienne śledzone w obecnym obiekcie.

Istniejące projekty się wysypią, każde pole `variable: Object` trzeba zamienić na `variables: [Object]`. Jak znajdę czas, to zrobię nową wersję bazy do importu.