### PR TITLE
Podłączenie domeny

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -3,4 +3,4 @@ BACKEND_PORT=40041
 
 BACKEND_URL=https://backend.algodebug.pl
 
-ORIGINS=https://algodebug.pl,https://test.algodebug.pl,http://localhost:8081
+ORIGINS=https://algodebug.pl,https://test.algodebug.pl,http://srv16.mikr.us:20232,http://srv16.mikr.us:30232,http://localhost:8081

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,6 @@
 FRONTEND_PORT=30232
 BACKEND_PORT=40041
 
-BACKEND_URL=http://srv16.mikr.us:40041
+BACKEND_URL=https://backend.algodebug.pl
 
-ORIGINS=http://srv16.mikr.us:20232,http://srv16.mikr.us:30232
+ORIGINS=https://algodebug.pl,https://test.algodebug.pl,http://localhost:8081

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AlgoDebug is a tool designed for debugging user provided source code through visualization of its operations. It was created primarily for people working with algorithmics and computer science students.
 
-Current version of application: <http://srv16.mikr.us:20232> (work in progress)
+Current version of application: <https://algodebug.pl> (work in progress)
 
 AlgoDebug compiler repository: <https://github.com/Rubix98/algodebug_compiler>
 

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -2,7 +2,7 @@
 # file not used by any service, stored here for convinience
 
 PORT=40041
-ORIGINS=https://algodebug.pl,https:test.algodebug.pl,http://localhost:8081
+ORIGINS=https://algodebug.pl,https://test.algodebug.pl,http://srv16.mikr.us:20232,http://srv16.mikr.us:30232,http://localhost:8081
 DATABASE_URI=mongodb+srv://AlgoDebug:AlgoDebug@streamchess.jlv3n.mongodb.net/
 DATABASE_NAME=AlgoDebug
 BACKEND_URL=https://backend.algodebug.pl

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -2,10 +2,10 @@
 # file not used by any service, stored here for convinience
 
 PORT=40041
-ORIGINS=http://srv16.mikr.us:20232,http://srv16.mikr.us:30232
+ORIGINS=https://algodebug.pl,https:test.algodebug.pl,http://localhost:8081
 DATABASE_URI=mongodb+srv://AlgoDebug:AlgoDebug@streamchess.jlv3n.mongodb.net/
 DATABASE_NAME=AlgoDebug
-BACKEND_URL=http://srv16.mikr.us:40041
+BACKEND_URL=https://backend.algodebug.pl
 
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/backend/src/compiler/compilers/AlgoDebugCompilerImpl.ts
+++ b/backend/src/compiler/compilers/AlgoDebugCompilerImpl.ts
@@ -3,7 +3,7 @@ import { OutputParser } from "../utils/OutputParser";
 import { Compiler } from "./compilerFactory";
 
 export class AlgoDebugCompilerImpl implements Compiler {
-    static API_URL: string = "http://srv16.mikr.us:40042/compile";
+    static API_URL: string = "https://compiler.algodebug.pl/compile";
 
     async compile(request: CompilerRequest): Promise<CompilerResponse> {
         const url = process.env.COMPILER_API_URL ?? AlgoDebugCompilerImpl.API_URL;

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,2 @@
 PORT=30232
-VITE_APP_BACKEND_URL=http://srv16.mikr.us:40041
+VITE_APP_BACKEND_URL=https://backend.algodebug.pl

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
     base: "/",
     assetsDir: "/",
     devServer: {
-        allowedHosts: ["srv16.mikr.us"],
+        allowedHosts: ["algodebug.pl"],
     },
     define: {
         BACKEND_URL: JSON.stringify(env.VITE_APP_BACKEND_URL),


### PR DESCRIPTION
https://trello.com/c/QHNVn7IP/89-pod%C5%82%C4%85czy%C4%87-now%C4%85-domen%C4%99-do-strony

Podłączenie nowej domeny. Zmiany z tego PR nie zostały jeszcze zmergowane, ale na mikrusie testowo odpaliłem wersję z poniższymi zmianami, także jak ktoś chce można się upewnić czy działa. Powinny działać i stare i nowe adresy. 
Adresy:
https://algodebug.pl -> http://srv16.mikr.us:20232
https://backend.algodebug.pl -> http://srv16.mikr.us:40041
https://compiler.algodebug.pl -> http://srv16.mikr.us:40042
https://test.algodebug.pl -> http://srv16.mikr.us:30232 (to jest zapasowy frontend na testy, aktualnie nic tam nie ma)