### PR TITLE
Deploy backend CD

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -1,0 +1,20 @@
+name: Deploy Backend
+
+on: [ workflow_dispatch ]
+
+jobs:
+  deploy_backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: "Run deploy script on server"
+        uses: garygrossgarten/github-action-ssh@release
+        with:
+          command: "bash deploy_backend.sh"
+          host: "${{ secrets.SFTP_ADDRESS }}"
+          port: "${{ secrets.SFTP_PORT }}"
+          username: "${{ secrets.SFTP_USERNAME }}"
+          password: "${{ secrets.SFTP_PASSWORD }}"


### PR DESCRIPTION
CD do wdrażania backendu.
Nie są wymagane żadne zmiany w sekretach - wersja ta powinna działać od razu po zmergowaniu z główną gałęzią. 
Zalecam teraz korzystanie wyłącznie z cd, aby nie naruszać uprawnień.