### PR TITLE
[Konwertery] Zmiana cout'ów na funkcje + typy proste

### DIFF
--- a/backend/src/compiler/types.d.ts
+++ b/backend/src/compiler/types.d.ts
@@ -28,5 +28,5 @@ export type CodeOutput = {
 export type CodeBreakpoint = {
     id: number;
     line: number;
-    variables: Record<string, string>;
+    sceneObjects: Record<string, string>;
 };

--- a/backend/src/compiler/utils/OutputParser.ts
+++ b/backend/src/compiler/utils/OutputParser.ts
@@ -2,7 +2,7 @@ import { CodeBreakpoint, CodeOutput } from "../types";
 import { parse } from "node-html-parser";
 
 const BREAKPOINT_TAG = "algodebug-breakpoint";
-const VARIABLE_TAG = "algodebug-variable";
+const SCENEOBJECT_TAG = "algodebug-object";
 
 const BREAKPOINT_BEGIN_TAG = "<algodebug-breakpoint";
 const BREAKPOINT_END_TAG = "</algodebug-breakpoint>\n";
@@ -62,19 +62,19 @@ export class OutputParser {
         const parsedBreakpoint = parse(breakpoint.tag).getElementsByTagName(BREAKPOINT_TAG)[0];
         let line = Number(parsedBreakpoint.getAttribute("line"));
 
-        let variables: Record<string, string> = {};
-        for (let variable of parsedBreakpoint.getElementsByTagName(VARIABLE_TAG)) {
-            let variableName = variable.getAttribute("name");
-            let variableValue = variable.innerHTML;
-            if (variableName) {
-                variables[variableName] = variableValue;
+        let sceneObjects: Record<string, string> = {};
+        for (let sceneObject of parsedBreakpoint.getElementsByTagName(SCENEOBJECT_TAG)) {
+            let objectId = sceneObject.getAttribute("id");
+            let objectValue = sceneObject.innerHTML;
+            if (objectId) {
+                sceneObjects[objectId] = objectValue;
             }
         }
 
-        return { id, line, variables };
+        return { id, line, sceneObjects };
     }
 
-    parseVariable(variable: Element) {
-        return [variable.getAttribute("name"), variable.innerHTML];
+    parseVariable(sceneObject: Element) {
+        return [sceneObject.getAttribute("name"), sceneObject.innerHTML];
     }
 }

--- a/frontend/src/javascript/codeParser/CodeParser.js
+++ b/frontend/src/javascript/codeParser/CodeParser.js
@@ -32,8 +32,9 @@ export class CodeParser {
         },
     };
 
-    constructor(code, variables, breakpoints, converters) {
+    constructor(code, sceneObjectsFlat, variables, breakpoints, converters) {
         this.code = code;
+        this.sceneObjectsFlat = sceneObjectsFlat;
         this.variables = variables;
         this.breakpoints = breakpoints;
         this.converters = converters;
@@ -45,6 +46,7 @@ export class CodeParser {
     }
 
     parse() {
+        console.log(this.sceneObjectsFlat);
         this.prepareCode();
 
         let tags = this.findAllPositionsOfEveryTag();
@@ -119,7 +121,7 @@ export class CodeParser {
 
     parseCode() {
         this.code = CodeParserUtils.removeVariableTags(this.code);
-        this.code = CodeParserUtils.replaceBreakpointTags(this.code, this.parsedBreakpoints);
+        this.code = CodeParserUtils.replaceBreakpointTags(this.code, this.sceneObjectsFlat, this.parsedBreakpoints);
         this.code = CodeParserUtils.insertConvertersAfterIncludes(this.code, this.converters);
         this.code = CodeParserUtils.insertConvertersAtTheEnd(this.code, this.converters);
         this.code = CodeParserUtils.insertAlgodebugMacros(this.code);

--- a/frontend/src/javascript/codeParser/CodeParser.js
+++ b/frontend/src/javascript/codeParser/CodeParser.js
@@ -46,7 +46,6 @@ export class CodeParser {
     }
 
     parse() {
-        console.log(this.sceneObjectsFlat);
         this.prepareCode();
 
         let tags = this.findAllPositionsOfEveryTag();

--- a/frontend/src/javascript/languages/cpp.js
+++ b/frontend/src/javascript/languages/cpp.js
@@ -1,3 +1,14 @@
+import defines from "./cpp/defines.cpp?raw";
+import defaultConverters from "./cpp/converters.cpp?raw";
+
+export function getDefines() {
+    return defines;
+}
+
+export function getDefaultConverters() {
+    return defaultConverters;
+}
+
 export const reservedKeywords = new Set([
     "alignas",
     "alignof",

--- a/frontend/src/javascript/languages/cpp/converters.cpp
+++ b/frontend/src/javascript/languages/cpp/converters.cpp
@@ -1,0 +1,18 @@
+template <class A, class B>
+std::ostream& operator<<(std::ostream& os, const std::pair<A,B>& p)
+{
+	os << p.first << " " << p.second << "\n";
+	return os;
+}
+template <class A, class B, class C>
+std::ostream& operator<<(std::ostream& os, const std::tuple<A,B,C>& t)
+{
+	os << std::get<0>(t) << " " << std::get<1>(t) << " " << std::get<2>(t) << "\n";
+	return os;
+}
+template <class A>
+std::ostream& operator<<(std::ostream& os, const std::vector<A>& v)
+{
+	for(auto e : v) os << e << "\n";
+	return os;
+}

--- a/frontend/src/javascript/languages/cpp/defines.cpp
+++ b/frontend/src/javascript/languages/cpp/defines.cpp
@@ -1,0 +1,3 @@
+#define ALGODEBUG_OBJECT(id, x) std::cout << "<algodebug-object " << "id=\"" << #id << "\">\n"; std::cout << x; std::cout << "\n</algodebug-object>\n"
+#define ALGODEBUG_BREAKPOINT_START(line) std::cout << "<algodebug-breakpoint " << "line=\"" << line << "\">\n"
+#define ALGODEBUG_BREAKPOINT_END() std::cout << "</algodebug-breakpoint>\n"

--- a/frontend/src/javascript/stage/Painter.js
+++ b/frontend/src/javascript/stage/Painter.js
@@ -12,13 +12,14 @@ export class Painter {
     }
 
     draw() {
-        this.model = this.getVariable(this.sceneObject);
+        this.model = this.getObjectData(this.sceneObject.id, this.sceneObject);
         if (!this.model) return;
 
         this.drawModel(this.model);
 
         for (let subobject of this.sceneObject.subobjects) {
-            let variable = this.getVariable(subobject);
+            let subobjectId = this.sceneObject.id + "_" + subobject.id;
+            let variable = this.getObjectData(subobjectId, subobject);
             if (!variable) continue;
             this.subobjectFunctionMap[subobject.type].call(this, variable, subobject);
         }
@@ -46,11 +47,9 @@ export class Painter {
         });
     }
 
-    getVariable(sceneObject) {
-        const id = sceneObject.variables[0].id;
-        const type = sceneObject.type;
-        let variable = this.frame.variables[id];
-        return variable ? parse(variable, type) : undefined;
+    getObjectData(id, sceneObject) {
+        let sceneObjectData = this.frame.sceneObjects[id];
+        return sceneObjectData ? parse(sceneObjectData, sceneObject.type) : undefined;
     }
 
     getPosition(name, defaultPosition = { x: 0, y: 0 }) {

--- a/frontend/src/javascript/utils/parsingUtils.js
+++ b/frontend/src/javascript/utils/parsingUtils.js
@@ -117,5 +117,5 @@ function parseCircles(value) {
 }
 
 function parseArrayOrString(value) {
-    return value.includes(" ") ? parseArray(value) : value;
+    return value.includes(" ") || value.includes("\n") ? parseArray(value) : value;
 }

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -19,7 +19,13 @@ export const useProjectStore = defineStore("project", {
 
     getters: {
         debugCode() {
-            return new CodeParser(this.code, this.variables, this.breakpoints, this.converters).parse();
+            return new CodeParser(
+                this.code,
+                this.sceneObjectsFlat,
+                this.variables,
+                this.breakpoints,
+                this.converters
+            ).parse();
         },
 
         variables() {
@@ -38,7 +44,12 @@ export const useProjectStore = defineStore("project", {
         },
 
         sceneObjectsFlat() {
-            return this.sceneObjects.flatMap((sceneObject) => [sceneObject, ...sceneObject.subobjects]);
+            return this.sceneObjects.flatMap((sceneObject) => [
+                sceneObject,
+                ...sceneObject.subobjects.map((subObject) => {
+                    return { ...subObject, id: sceneObject.id + "_" + subObject.id };
+                }),
+            ]);
         },
 
         currentTestCase() {


### PR DESCRIPTION
https://trello.com/c/HgYPmlzy/102-konwertery-zmiana-cout%C3%B3w-na-funkcj%C4%99

Od teraz przy każdym breakpoincie dla każdego obiektu sprawdzamy, czy wszystkie jego zmienne są dostępne. Jeśli tak, to wywołujemy konwerter (który zwraca std::string) i go wywołujemy.

Uwaga (TODO) nr 1: Trzeba dodać walidację ilości zmiennych i argumentów konwertera. Domyślny (czyli po prostu cout) może mieć 1 zmienną, przykładowy konwerter string(vector, int = 0) może mieć 1 lub 2, więc tutaj też dosyć skomplikowane zadanie, zostawiam to na innego taska, można śmiało brać.

Uwaga (TODO) nr 2: Kolejność zmiennych podanych w obiekcie jest ważna, bo w takiej kolejności są wrzucane do konwertera. Aktualnie żeby ją zmienić, trzeba odklikać istniejące obiekty i zaznaczyć je na nowo, w pożądanej kolejności. Jako kolejny task zostawiam przesuwanie kolejności zmiennych w oknie wyboru śledzonych zmiennych.

Uwaga nr 3: Aktualnie trzymamy w bazie projekty, które wewnątrz przechowują CAŁE konwertery. Dla każdej zmiennej. Nie wiem, z czego to wynika, ale trochę wydaje mi się to dziwne. Można przecież trzymać tylko ID do konwertera w głównej bazie, lub cały konwerter, jeśli nie jest zapisany publicznie. No nie przeszkadza to bardzo, więc nie krzyczę TODO REFACTOR, ale przez to (znowu) muszę updatować wszystkie konwertery ORAZ projekty > obiekty + podobiekty > konwertery. Postaram się jeszcze dzisiaj to zrobić. Do testów można skorzystać z mojej bazy, projekt "Otoczka wypukła" [by Łukasz Skabowski] jest już przerobiony.

Uwaga nr 3.5: Skoro kolejny task i tak przerobi konwertery na typy "prawie-proste", to czy jest sens teraz wszystkie projekty + konwertery przerabiać?