### PR TITLE
Usunięcie niepotrzebnych linijek w Deploy Backend

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -6,10 +6,6 @@ jobs:
   deploy_backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: "Run deploy script on server"
         uses: garygrossgarten/github-action-ssh@release
         with:


### PR DESCRIPTION
Deploy Backend checkoutuje projekt oraz instaluje NodeJs a jest mu to niepotrzebne.
Ten PR usuwa te kroki i zostawia tylko odpalenie skryptu, który aktualizuje backend na VPS.