### PR TITLE
Dodanie funkcji canUserReadProject and canUserEditProject

### DIFF
--- a/backend/src/project/endpoints.ts
+++ b/backend/src/project/endpoints.ts
@@ -3,8 +3,8 @@ import { ObjectId } from "mongodb";
 import { getCollections } from "../db";
 import {
     validateProject,
-    isUserAuthorised,
-    isUserAuthor,
+    canUserReadProject,
+    canUserEditProject,
     getAllProjectsWithAuthor,
     getProjectByIdWithAuthor,
 } from "./service";
@@ -47,7 +47,7 @@ export const getProjectById = async (req: Request, res: Response) => {
 
     const user = req.user as User;
 
-    if (isUserAuthorised(result, user)) {
+    if (canUserReadProject(user, result)) {
         res.status(200).json(result);
     } else {
         res.status(403).json({ error: "User is not authorised" });
@@ -121,7 +121,7 @@ export const updateProject = async (req: Request, res: Response) => {
         return;
     }
 
-    if (!isUserAuthor(projectToEdit, user)) {
+    if (!canUserEditProject(user, projectToEdit)) {
         res.status(401).json({ error: "You are not authorised to edit this project" });
         return;
     }

--- a/backend/src/project/service.ts
+++ b/backend/src/project/service.ts
@@ -45,7 +45,7 @@ export const canUserReadProject = (user: User, project: ProjectLike): boolean =>
 };
 
 export const canUserEditProject = (user: User, project: ProjectLike): boolean => {
-    return canUserReadProject(user, project) && isUserAuthorOfProject(user, project);
+    return isUserAuthorOfProject(user, project);
 };
 
 /**

--- a/backend/src/project/service.ts
+++ b/backend/src/project/service.ts
@@ -36,15 +36,15 @@ export const validateProject = (req: unknown): ValidTypeOrError<Project> => {
     }
 };
 
-const isUserAuthorOfProject = (user: User, project: ProjectLike, ): boolean => {
+const isUserAuthorOfProject = (user: User, project: ProjectLike): boolean => {
     return project.authorId.equals(new ObjectId(user?._id));
 };
 
-export const canUserReadProject = (user: User, project: ProjectLike, ): boolean => {
+export const canUserReadProject = (user: User, project: ProjectLike): boolean => {
     return project.public || isUserAuthorOfProject(user, project);
 };
 
-export const canUserEditProject = (user: User, project: ProjectLike, ): boolean => {
+export const canUserEditProject = (user: User, project: ProjectLike): boolean => {
     return canUserReadProject(user, project) && isUserAuthorOfProject(user, project);
 };
 

--- a/backend/src/project/service.ts
+++ b/backend/src/project/service.ts
@@ -26,6 +26,8 @@ const authorLookup = [
     },
 ];
 
+const canUserReadProjectDBQuery = (userId: ObjectId) => ({ $match: { $or: [{ public: true }, { authorId: userId }] } });
+
 export const validateProject = (req: unknown): ValidTypeOrError<Project> => {
     try {
         return [true, sanitizeProject(Project.check(req))];
@@ -34,12 +36,16 @@ export const validateProject = (req: unknown): ValidTypeOrError<Project> => {
     }
 };
 
-export const isUserAuthor = (project: ProjectLike, user: User): boolean => {
+const isUserAuthorOfProject = (user: User, project: ProjectLike, ): boolean => {
     return project.authorId.equals(new ObjectId(user?._id));
 };
 
-export const isUserAuthorised = (project: ProjectLike, user: User): boolean => {
-    return isUserAuthor(project, user) || project.public;
+export const canUserReadProject = (user: User, project: ProjectLike, ): boolean => {
+    return project.public || isUserAuthorOfProject(user, project);
+};
+
+export const canUserEditProject = (user: User, project: ProjectLike, ): boolean => {
+    return canUserReadProject(user, project) && isUserAuthorOfProject(user, project);
 };
 
 /**
@@ -52,7 +58,7 @@ export const getAllProjectsWithAuthor = async (user?: User): Promise<ProjectLike
     const id = new ObjectId(user?._id);
 
     const result = await projects
-        .aggregate([{ $match: { $or: [{ public: true }, { authorId: id }] } }, ...authorLookup])
+        .aggregate([canUserReadProjectDBQuery(id), ...authorLookup])
         .sort({ modificationDate: -1 })
         .toArray();
 

--- a/frontend/src/javascript/utils/authorizationUtils.js
+++ b/frontend/src/javascript/utils/authorizationUtils.js
@@ -7,5 +7,5 @@ export function canUserReadProject(user, project) {
 }
 
 export function canUserEditProject(user, project) {
-    return canUserReadProject(user, project) && isUserAuthorOfProject(user, project);
+    return isUserAuthorOfProject(user, project);
 }

--- a/frontend/src/javascript/utils/authorizationUtils.js
+++ b/frontend/src/javascript/utils/authorizationUtils.js
@@ -1,0 +1,11 @@
+function isUserAuthorOfProject(user, project) {
+  return project.authorId == user?._id;
+};
+
+export function canUserReadProject(user, project) {
+  return isUserAuthorOfProject(user, project) || project.public;
+}
+
+export function canUserEditProject(user, project) {
+  return canUserReadProject(user, project) && isUserAuthorOfProject(user, project);
+}

--- a/frontend/src/javascript/utils/authorizationUtils.js
+++ b/frontend/src/javascript/utils/authorizationUtils.js
@@ -1,11 +1,11 @@
 function isUserAuthorOfProject(user, project) {
-  return project.authorId == user?._id;
-};
+    return project.authorId == user?._id;
+}
 
 export function canUserReadProject(user, project) {
-  return isUserAuthorOfProject(user, project) || project.public;
+    return isUserAuthorOfProject(user, project) || project.public;
 }
 
 export function canUserEditProject(user, project) {
-  return canUserReadProject(user, project) && isUserAuthorOfProject(user, project);
+    return canUserReadProject(user, project) && isUserAuthorOfProject(user, project);
 }

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -11,6 +11,7 @@ export const useProjectStore = defineStore("project", {
         breakpoints: [],
         testData: [{ id: 0, input: "" }],
         sceneObjects: [],
+        authorId: null,
         public: false,
         isRunning: false,
         waitingForCompile: false,
@@ -168,7 +169,7 @@ export const useProjectStore = defineStore("project", {
                     "language",
                     "testData",
                     "sceneObjects",
-                    "title",
+                    "authorId",
                     "public",
                 ].forEach((property) => (this[property] = project[property]));
                 this.currentTestCaseId = project.testData.firstId();


### PR DESCRIPTION
https://trello.com/c/Wpu3A9mE/129-przygotowanie-funkcji-canuserreadproject-i-can-usereditproject

Dodałem funkcje canUserReadProject(user, project) i canUserEditProject(user, project) zarówno na frontendzie (plik authorizationUtils,js) jak i backendzie (plik project/service.ts). Dodatkowo do filtrowania listy projektów, które użytkownik może wyświetlać jest osobna funkcja, która generuje odpowiednie zapytanie do bazy danych.

Tip jak ktoś będzie używał tych funkcji na frontendzie to żeby pobrać odpowiednie obiekty usera i projektu używamy poleceń
- `const project = useProjectStore().$state;`
- `const user = useUserStore().$state.user;`