### PR TITLE
Przerobienie wyglądu wyboru konwertera

### DIFF
--- a/frontend/src/components/global/AlgoCode.vue
+++ b/frontend/src/components/global/AlgoCode.vue
@@ -16,7 +16,7 @@
 
         methods: {
             getEditorTheme() {
-                if (getCurrentThemeFromStorage() === "light") return "vs-light";
+                if (getCurrentThemeFromStorage() === "light") return "vs";
                 return "vs-dark";
             },
         },

--- a/frontend/src/components/global/AlgoCode.vue
+++ b/frontend/src/components/global/AlgoCode.vue
@@ -1,0 +1,31 @@
+<template>
+    <pre :data-lang="this.$props.language">{{ this.$props.code }}</pre>
+</template>
+
+<script>
+    import { defineComponent } from "vue";
+    import * as monaco from "monaco-editor/esm/vs/editor/editor.main";
+    import { getCurrentThemeFromStorage } from "@/javascript/storage/themeStorage";
+
+    export default defineComponent({
+        props: ["code", "language"],
+
+        mounted() {
+            monaco.editor.colorizeElement(this.$el, { theme: this.getEditorTheme() });
+        },
+
+        methods: {
+            getEditorTheme() {
+                if (getCurrentThemeFromStorage() === "light") return "vs-light";
+                return "vs-dark";
+            },
+        },
+    });
+</script>
+
+<style scoped>
+    pre {
+        border: 1px solid gray;
+        padding: 4px;
+    }
+</style>

--- a/frontend/src/components/global/AlgoCode.vue
+++ b/frontend/src/components/global/AlgoCode.vue
@@ -27,5 +27,7 @@
     pre {
         border: 1px solid gray;
         padding: 4px;
+        overflow: scroll;
+        max-height: 220px;
     }
 </style>

--- a/frontend/src/components/global/AlgoPickList.vue
+++ b/frontend/src/components/global/AlgoPickList.vue
@@ -16,16 +16,10 @@
                         <v-list-item-title v-if="index === 0">
                             {{ property.value }}
                         </v-list-item-title>
-                        <v-list-item-subtitle v-else>
-                            {{ property.label }}:
-
-                            <span v-if="property.fieldType === 'textarea'">
-                                <AlgoTextarea class="small" :value="property.value" :readonly="true" />
-                            </span>
-                            <span v-else>
-                                {{ property.value }}
-                            </span>
+                        <v-list-item-subtitle v-else-if="property.fieldType !== 'textarea'">
+                            {{ property.label }}: {{ property.value }}
                         </v-list-item-subtitle>
+                        <AlgoCode v-else :code="property.value" :language="property.language" class="code" />
                     </div>
                 </div>
                 <v-list-item-title v-else>
@@ -38,11 +32,11 @@
 </template>
 
 <script>
-    import AlgoTextarea from "@/components/global/AlgoTextarea.vue";
+    import AlgoCode from "@/components/global/AlgoCode.vue";
     import { defineComponent } from "vue";
 
     export default defineComponent({
-        components: { AlgoTextarea },
+        components: { AlgoCode },
         emits: ["selectOptionEvent"],
         props: ["options"],
 
@@ -60,5 +54,12 @@
     a {
         color: inherit;
         text-decoration: inherit;
+    }
+</style>
+
+<style scoped>
+    .code {
+        margin-top: 5px;
+        margin-bottom: 30px;
     }
 </style>

--- a/frontend/src/components/mainPage/codeEditor/CodeViewer.vue
+++ b/frontend/src/components/mainPage/codeEditor/CodeViewer.vue
@@ -46,6 +46,7 @@
         mounted() {
             this.updateAllDecorations();
             this.emitter.on("themeChangeEvent", () => {
+                monaco.editor.setTheme(this.getEditorTheme());
                 this.options.theme = this.getEditorTheme();
             });
         },

--- a/frontend/src/components/mainPage/codeEditor/CodeViewer.vue
+++ b/frontend/src/components/mainPage/codeEditor/CodeViewer.vue
@@ -67,7 +67,7 @@
             },
 
             getEditorTheme() {
-                if (getCurrentThemeFromStorage() === "light") return "vs-light";
+                if (getCurrentThemeFromStorage() === "light") return "vs";
                 return "vs-dark";
             },
 

--- a/frontend/src/javascript/utils/dialogUtils.js
+++ b/frontend/src/javascript/utils/dialogUtils.js
@@ -14,7 +14,7 @@ export function getDialogDataForConverter(converter) {
     return {
         properties: [
             { label: "Nazwa", value: converter.title },
-            { label: "Kod", value: converter.code, fieldType: "textarea" },
+            { label: "Kod", value: converter.code, fieldType: "textarea", language: converter.language },
         ],
     };
 }


### PR DESCRIPTION
https://trello.com/c/bgrA0GlF/74-przerobienie-wygl%C4%85du-wyboru-konwertera

Dodałem komponent AlgoCode, który elegancko wyświetla kod.
![obraz](https://user-images.githubusercontent.com/27860636/234045577-cb01e786-3c2e-4905-96e8-76529152f8c0.png)

Uporządkowałem też trochę AlgoPickList. Zmieniłem nazwę motywu "vs-light" na "vs", bo taka jest poprawnie zdefiniowana przez Monaco (chociaż "vs-light" nie istnieje, więc jest ustawiana domyślna "vs", więc działało tak samo).

Uwaga: `monaco.editor.colorizeElement` to najdziwniejsza funkcja biblioteczna z jaką miałem do tej pory do czynienia (jej kuzyn `monaco.editor.colorize` zachowuje się tak samo). Jako drugi argument przyjmuje opcje, w których opcjonalnie można podać `theme`. Niezależnie jednak, czy go podamy, czy nie (wtedy zostanie ustawiony domyślny, jasny), to ta funkcja modyfikuje jakieś globalne ustawienia wyświetlania WSZYSTKICH edytorów na stronie (nawet tych, które jasno mają ustalone `theme: "vs-dark"`. Dlatego po otwarciu modala z konwerterami, motyw edytora głównego zamrażał się. Pewnym sposobem na to jest dodatkowa linia w CodeViewer.vue, konkretnie: `monaco.editor.setTheme(this.getEditorTheme());`. To zdaje się edytować te globalne ustawienia (zgaduje, że to jakiś arkusz styli, bo elementy po pokolorowaniu dostają spany z klasami, a nie stylami). Mimo to, jest to jakiś workaround.