### PR TITLE
[Kompilator] Wyświetlanie części outputu

### DIFF
--- a/backend/src/compiler/compilers/AlgoDebugCompilerImpl.ts
+++ b/backend/src/compiler/compilers/AlgoDebugCompilerImpl.ts
@@ -22,6 +22,7 @@ export class AlgoDebugCompilerImpl implements Compiler {
             return {
                 success: true,
                 output: new OutputParser(response.output).parse(),
+                error: response.error,
             };
         } else {
             return {
@@ -36,6 +37,7 @@ export class AlgoDebugCompilerImpl implements Compiler {
 type AlgoDebugCompilerApiResponse = {
     success: true;
     output: string;
+    error: string;
 } | {
     success: false;
     error: string;

--- a/backend/src/compiler/endpoints.ts
+++ b/backend/src/compiler/endpoints.ts
@@ -10,16 +10,9 @@ export const compileCode = async (req: Request, res: Response) => {
         return;
     }
     try {
-        let response = await sendRequestsToCompilerAPI(req.body);
-        let numberOfErrors = response.filter((response) => !response.success).length;
-        if (numberOfErrors === 0) {
-            res.status(200).json(response);
-        } else if (numberOfErrors < response.length) {
-            res.status(206).json(response);
-        } else {
-            let errorMessage = response.map((response) => (!response.success ? response.error : "")).join("\n");
-            res.status(400).json(errorMessage);
-        }
+        const [isOk, response] = await sendRequestsToCompilerAPI(req.body);
+        let status = isOk ? 200 : 400;
+        res.status(status).json(response);
     } catch (err) {
         console.log(err);
         res.status(500).json(err);

--- a/backend/src/compiler/service.ts
+++ b/backend/src/compiler/service.ts
@@ -2,7 +2,9 @@ import { CompilerMultiTestsRequest, CompilerResponse } from "./types";
 import { Code } from "./structures/Code";
 import { getCompiler } from "./compilers/compilerFactory";
 
-export async function sendRequestsToCompilerAPI(request: CompilerMultiTestsRequest): Promise<CompilerResponse[]> {
+export async function sendRequestsToCompilerAPI(
+    request: CompilerMultiTestsRequest
+): Promise<[true, CompilerResponse[]] | [false, string]> {
     let results: CompilerResponse[] = [];
     const compiler = getCompiler();
     for (const input of request.inputs) {
@@ -11,10 +13,10 @@ export async function sendRequestsToCompilerAPI(request: CompilerMultiTestsReque
             input: input,
             language: request.language,
         });
+        if (!result.success) return [false, result.error];
         results.push(result);
-        if (!result.success) return results;
     }
-    return results;
+    return [true, results];
 }
 
 type validCodeOrError = [true, Code] | [false, unknown];

--- a/backend/src/compiler/types.d.ts
+++ b/backend/src/compiler/types.d.ts
@@ -14,13 +14,13 @@ export type CompilerRequest = {
 export type CompilerResponse = {
     success: true;
     output: CodeOutput;
+    error?: string
 } | {
     success: false;
     error: string;
 }
 
 export type CodeOutput = {
-    fullOutput: string;
     partialOutputs: string[];
     frames: CodeBreakpoint[];
 };

--- a/backend/src/compiler/utils/OutputParser.ts
+++ b/backend/src/compiler/utils/OutputParser.ts
@@ -23,7 +23,6 @@ export class OutputParser {
 
     parse(): CodeOutput {
         let result: CodeOutput = {
-            fullOutput: this.output,
             partialOutputs: [],
             frames: [],
         };
@@ -36,7 +35,9 @@ export class OutputParser {
                 this.position = breakpoint.end;
             }
         } while (found);
-        result.partialOutputs.push(this.output.substring(this.position));
+        if (!this.output.substring(this.position).includes(BREAKPOINT_TAG)) {
+            result.partialOutputs.push(this.output.substring(this.position));
+        }
 
         return result;
     }

--- a/frontend/src/components/global/AlgoTooltip.vue
+++ b/frontend/src/components/global/AlgoTooltip.vue
@@ -1,7 +1,7 @@
 <template>
     <v-tooltip :text="text">
         <template v-slot:activator="{ props }">
-            <v-icon size="25" v-bind="props" @click="handleClick">{{ icon }}</v-icon>
+            <v-icon size="25" :color="color" v-bind="props">{{ icon }}</v-icon>
         </template>
     </v-tooltip>
 </template>
@@ -17,14 +17,8 @@
             icon: {
                 type: String,
             },
-            onClick: {
-                type: Function,
-            },
-        },
-
-        methods: {
-            handleClick() {
-                this.onClick(); // Wywołanie dostarczonej funkcji onClick
+            color: {
+                type: String,
             },
         },
     });

--- a/frontend/src/components/mainPage/testData/TestData.vue
+++ b/frontend/src/components/mainPage/testData/TestData.vue
@@ -13,6 +13,14 @@
             </AlgoBlock>
 
             <AlgoBlock class="full-size ma-0" header="Dane wyjściowe" v-if="this.isRunning">
+                <template #tooltip>
+                    <AlgoTooltip
+                        v-if="compilationError"
+                        icon="mdi-exclamation-thick"
+                        :text="compilationError"
+                        color="red"
+                    ></AlgoTooltip>
+                </template>
                 <template #checkbox>
                     <v-checkbox-btn
                         v-model="isDynamicOutputOn"
@@ -31,10 +39,10 @@
                     <AlgoTooltip
                         icon="mdi-help-circle"
                         text="Poniższy błąd dotyczy kodu debugującego. Kliknij aby zobaczyć szczegóły"
-                        :onClick="showExtendedCode"
+                        @click="showExtendedCode"
                     ></AlgoTooltip>
                 </template>
-                <AlgoTextarea :value="output" :auto-grow="true" :readonly="true" />
+                <AlgoTextarea :value="compilationError" :auto-grow="true" :readonly="true" />
             </AlgoBlock>
         </div>
     </div>
@@ -84,12 +92,12 @@
             },
 
             output() {
-                if (!this.lastCompilationSuccess) {
-                    return this.currentTestCase.error;
-                }
                 let endIndex = this.isDynamicOutputOn ? this.currentFrame.id + 1 : undefined;
-
                 return this.currentTestCase.partialOutputs.slice(0, endIndex).join("");
+            },
+
+            compilationError() {
+                return this.currentTestCase.error;
             },
         },
     });

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -216,6 +216,7 @@ export const useProjectStore = defineStore("project", {
                 .then((responseData) => {
                     this.testData.forEach((testCase, index) => {
                         Object.assign(testCase, responseData[index].output);
+                        testCase.error = responseData[index].error;
                     });
                     this.isRunning = true;
                     this.lastCompilationSuccess = true;


### PR DESCRIPTION
https://trello.com/c/Xb07VDEi/136-kompilator-wy%C5%9Bwietlanie-cz%C4%99%C5%9Bci-outputu

Link do PR na algodebug_compiler: https://github.com/Rubix98/algodebug_compiler/pull/3

Dodałem wyświetlanie części otuputu, którą udało się wygenerować przed wystąpieniem jednego z poniższych błędów
- przekroczenie limitu czasu na wykonanie programu
- przekroczenie limutu znaków w outpucie
- runtime error

Takie przypadki traktowane są jako udane wykonanie (zmienna `success = true`), ale mają dodatkowy parametr `error` z opisem błędu. W bloku "dane wyjściowe" pojawia się ikonka `!` z komunikatem błędu.

Jeżeli output zakończy się wewnątrz tagu `algodebug-breakpoint` to ten niedokończony breakpoint jest usuwany z wyjścia. Może zdarzyć się sytuacja w której program zakończy się na np `<algodebug-brea`. Wtedy ten fragment zostanie wyświetlony, bo nie chciałem za bardzo analizować dla jakiego prefiksu tego słowa to jest coś wstawionego przez nas czy przez użytkownika. Raczej to i tak jest mała szansa, że coś takiego wystąpi (choć prawdopodobna).

Usunąłem atrybut `fullOutput` bo to nie było właściwie nigdzie nie wykorzystywane, a niepotrzebnie zwiększało nakład pamięciowy.

Drobne poprawki do tooltipa.

Zmniejszyłem znacząco limit na rozmiar przesyłanego outputu, bo dla tych 256MB miałem sytuacje, że jak odpalałem jakiś program, który generował dużą ilość danych to mi zawieszało czasami przeglądarkę a czasami cały system. To jest problem frontendu, bo podczas przesyłania takich danych (nawet te 256MB) z kompilatora do backendu i z backendu do frontendu nie ma żadnych problemów i wszystko działa w miarę szybko. Postaram się to jeszcze trochę zweryfikować bardziej ten temat i założę osobne zadanie na rozwiązanie tego.
EDIT: Ok, ten limit, który ustawiłem 1 MB był zbyt radykalny ustawiłem limit na 32MB, myślę, że to jest taki w miarę optymalny limit, ale trzeba to będzie jeszcze monitorować.